### PR TITLE
Prepare package metadata and stable SDK dependencies

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,39 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - README.md
+
+  pull_request:
+    paths-ignore:
+      - README.md
+
+env:
+  IS_CICD: 1
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore
+        run: dotnet restore ScyllaDB.Alternator.sln --verbosity minimal
+
+      - name: Build
+        run: make build
+
+      - name: Check formatting
+        run: make check
+
+      - name: Run unit tests
+        run: make test-unit

--- a/IntegrationTests/ScyllaDB.Alternator.Test.csproj
+++ b/IntegrationTests/ScyllaDB.Alternator.Test.csproj
@@ -18,7 +18,7 @@
         <PackageReference Include="NUnit" Version="4.2.2" />
         <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-        <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.0-preview.4" />
+        <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.21.7" />
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
         <PackageReference Include="NLog.Extensions.Logging" Version="5.3.15" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/ScyllaDB.Alternator.csproj
+++ b/ScyllaDB.Alternator.csproj
@@ -4,16 +4,24 @@
   <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+        <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
         <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <NoWarn>$(NoWarn);CS1591;SA0001;SA1600;SA1633;SA1636;SA1518</NoWarn>
+        <PackageId>ScyllaDB.Alternator</PackageId>
+        <VersionPrefix>2.0.5</VersionPrefix>
+        <Authors>ScyllaDB</Authors>
+        <Company>ScyllaDB</Company>
+        <Description>Scylla Alternator client-side load balancing for the AWS SDK DynamoDB client.</Description>
+        <PackageTags>scylladb;alternator;dynamodb;aws-sdk;load-balancing</PackageTags>
+        <PackageProjectUrl>https://github.com/scylladb/alternator-client-csharp</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/scylladb/alternator-client-csharp</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.0-preview.4" />
-      <PackageReference Include="CommandLineParser" Version="2.9.1" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+      <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.21.7" />
       <PackageReference Include="NLog.Extensions.Logging" Version="5.3.15" />
       <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -32,12 +40,6 @@
 
     <ItemGroup>
       <Folder Include="Helper\" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Reference Include="nunit.framework">
-        <HintPath>..\..\..\..\home\dmitry.kropachev\.nuget\packages\nunit\4.2.2\lib\net6.0\nunit.framework.dll</HintPath>
-      </Reference>
     </ItemGroup>
 
 </Project>

--- a/UnitTests/ScyllaDB.Alternator.Test.csproj
+++ b/UnitTests/ScyllaDB.Alternator.Test.csproj
@@ -18,7 +18,7 @@
         <PackageReference Include="NUnit" Version="4.2.2" />
         <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-        <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.0-preview.4" />
+        <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.21.7" />
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
         <PackageReference Include="NLog.Extensions.Logging" Version="5.3.15" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">


### PR DESCRIPTION
## Summary
- add NuGet package metadata and assembly info generation to the library project
- move the library project off preview AWSSDK.DynamoDBv2 and remove test-only references
- align test projects on the same stable AWSSDK.DynamoDBv2 package

## Local verification
- dotnet restore ScyllaDB.Alternator.sln --verbosity minimal
- dotnet build ScyllaDB.Alternator.csproj --configuration Release --verbosity minimal
- dotnet build UnitTests/ScyllaDB.Alternator.Test.csproj --configuration Release --verbosity minimal
- dotnet build IntegrationTests/ScyllaDB.Alternator.Test.csproj --configuration Release --verbosity minimal
- dotnet format --verify-no-changes --severity warn --verbosity diagnostic ScyllaDB.Alternator.csproj
- dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj --filter "Category=Unit" --verbosity minimal
