### PR TITLE
Add Alternator config value objects

### DIFF
--- a/AlternatorConfig.cs
+++ b/AlternatorConfig.cs
@@ -1,0 +1,314 @@
+// <copyright file="AlternatorConfig.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    using ScyllaDB.Alternator.KeyRouting;
+    using ScyllaDB.Alternator.Routing;
+
+    public class AlternatorConfig
+    {
+        public const int DefaultMinCompressionSizeBytes = 1024;
+        public const long DefaultActiveRefreshIntervalMs = 1000;
+        public const long DefaultIdleRefreshIntervalMs = 60000;
+        public const int DefaultMaxConnections = 400;
+        public const long DefaultConnectionMaxIdleTimeMs = 600000;
+        public const long DefaultConnectionTimeToLiveMs = 0;
+        public const long DefaultConnectionAcquisitionTimeoutMs = 10000;
+        public const long DefaultConnectionTimeoutMs = 15000;
+        public const int RecommendedPartitionKeyDiscoveryMaxRetries = 3;
+        public const long RecommendedPartitionKeyDiscoveryInitialDelayMs = 100;
+        public const long RecommendedPartitionKeyDiscoveryMaxDelayMs = 2000;
+        public const long RecommendedPartitionKeyDiscoveryCooldownMs = 5 * 60 * 1000;
+
+#pragma warning disable SA1310, IDE1006
+        public const int DEFAULT_MIN_COMPRESSION_SIZE_BYTES = DefaultMinCompressionSizeBytes;
+        public const long DEFAULT_ACTIVE_REFRESH_INTERVAL_MS = DefaultActiveRefreshIntervalMs;
+        public const long DEFAULT_IDLE_REFRESH_INTERVAL_MS = DefaultIdleRefreshIntervalMs;
+        public const int DEFAULT_MAX_CONNECTIONS = DefaultMaxConnections;
+        public const long DEFAULT_CONNECTION_MAX_IDLE_TIME_MS = DefaultConnectionMaxIdleTimeMs;
+        public const long DEFAULT_CONNECTION_TIME_TO_LIVE_MS = DefaultConnectionTimeToLiveMs;
+        public const long DEFAULT_CONNECTION_ACQUISITION_TIMEOUT_MS = DefaultConnectionAcquisitionTimeoutMs;
+        public const long DEFAULT_CONNECTION_TIMEOUT_MS = DefaultConnectionTimeoutMs;
+        public const int RECOMMENDED_PARTITION_KEY_DISCOVERY_MAX_RETRIES = RecommendedPartitionKeyDiscoveryMaxRetries;
+        public const long RECOMMENDED_PARTITION_KEY_DISCOVERY_INITIAL_DELAY_MS = RecommendedPartitionKeyDiscoveryInitialDelayMs;
+        public const long RECOMMENDED_PARTITION_KEY_DISCOVERY_MAX_DELAY_MS = RecommendedPartitionKeyDiscoveryMaxDelayMs;
+        public const long RECOMMENDED_PARTITION_KEY_DISCOVERY_COOLDOWN_MS = RecommendedPartitionKeyDiscoveryCooldownMs;
+#pragma warning restore SA1310, IDE1006
+
+        public static readonly IReadOnlySet<string> BaseRequiredHeaders = CreateReadOnlyHeaderSet(new[]
+        {
+            "Host",
+            "X-Amz-Target",
+            "Content-Type",
+            "Content-Length",
+            "Accept-Encoding",
+            "Connection",
+        });
+
+        public static readonly IReadOnlySet<string> UserAgentHeaders = CreateReadOnlyHeaderSet(new[]
+        {
+            "User-Agent",
+        });
+
+        public static readonly IReadOnlySet<string> CompressionHeaders = CreateReadOnlyHeaderSet(new[]
+        {
+            "Content-Encoding",
+        });
+
+        public static readonly IReadOnlySet<string> AuthenticationHeaders = CreateReadOnlyHeaderSet(new[]
+        {
+            "Authorization",
+            "X-Amz-Date",
+        });
+
+#pragma warning disable SA1310, IDE1006
+        public static readonly IReadOnlySet<string> BASE_REQUIRED_HEADERS = BaseRequiredHeaders;
+        public static readonly IReadOnlySet<string> USER_AGENT_HEADERS = UserAgentHeaders;
+        public static readonly IReadOnlySet<string> COMPRESSION_HEADERS = CompressionHeaders;
+        public static readonly IReadOnlySet<string> AUTHENTICATION_HEADERS = AuthenticationHeaders;
+#pragma warning restore SA1310, IDE1006
+
+        internal AlternatorConfig(
+            List<string> seedHosts,
+            string scheme,
+            int port,
+            RoutingScope routingScope,
+            RequestCompressionAlgorithm compressionAlgorithm,
+            int minCompressionSizeBytes,
+            bool optimizeHeaders,
+            ISet<string>? headersWhitelist,
+            bool userAgentEnabled,
+            bool authenticationEnabled,
+            KeyRouteAffinityConfig? keyRouteAffinityConfig,
+            long activeRefreshIntervalMs,
+            long idleRefreshIntervalMs,
+            int maxConnections,
+            long connectionMaxIdleTimeMs,
+            long connectionTimeToLiveMs,
+            long connectionAcquisitionTimeoutMs,
+            long connectionTimeoutMs,
+            TlsSessionCacheConfig? tlsSessionCacheConfig,
+            TlsConfig tlsConfig)
+        {
+            this.SeedHosts = seedHosts.AsReadOnly();
+            this.Scheme = scheme;
+            this.Port = port;
+            this.RoutingScope = routingScope;
+            this.CompressionAlgorithm = compressionAlgorithm;
+            this.MinCompressionSizeBytes = minCompressionSizeBytes >= 0 ? minCompressionSizeBytes : DefaultMinCompressionSizeBytes;
+            this.OptimizeHeaders = optimizeHeaders;
+            this.UserAgentEnabled = userAgentEnabled;
+            this.AuthenticationEnabled = authenticationEnabled;
+            this.HeadersWhitelist = this.CreateHeadersWhitelist(headersWhitelist);
+            this.KeyRouteAffinityConfig = keyRouteAffinityConfig;
+            this.ActiveRefreshIntervalMs = activeRefreshIntervalMs > 0 ? activeRefreshIntervalMs : DefaultActiveRefreshIntervalMs;
+            this.IdleRefreshIntervalMs = idleRefreshIntervalMs > 0 ? idleRefreshIntervalMs : DefaultIdleRefreshIntervalMs;
+            this.MaxConnections = maxConnections;
+            this.ConnectionMaxIdleTimeMs = connectionMaxIdleTimeMs;
+            this.ConnectionTimeToLiveMs = connectionTimeToLiveMs;
+            this.ConnectionAcquisitionTimeoutMs = connectionAcquisitionTimeoutMs;
+            this.ConnectionTimeoutMs = connectionTimeoutMs;
+            this.TlsSessionCacheConfig = tlsSessionCacheConfig ?? TlsSessionCacheConfig.GetDefault();
+            this.TlsConfig = tlsConfig;
+        }
+
+        public IReadOnlyList<string> SeedHosts { get; }
+
+        public string Scheme { get; }
+
+        public int Port { get; }
+
+        public RoutingScope RoutingScope { get; }
+
+        public RequestCompressionAlgorithm CompressionAlgorithm { get; }
+
+        public int MinCompressionSizeBytes { get; }
+
+        public bool OptimizeHeaders { get; }
+
+        public IReadOnlySet<string> HeadersWhitelist { get; }
+
+        public bool UserAgentEnabled { get; }
+
+        public bool AuthenticationEnabled { get; }
+
+        public KeyRouteAffinityConfig? KeyRouteAffinityConfig { get; }
+
+        public long ActiveRefreshIntervalMs { get; }
+
+        public long IdleRefreshIntervalMs { get; }
+
+        public int MaxConnections { get; }
+
+        public long ConnectionMaxIdleTimeMs { get; }
+
+        public long ConnectionTimeToLiveMs { get; }
+
+        public long ConnectionAcquisitionTimeoutMs { get; }
+
+        public long ConnectionTimeoutMs { get; }
+
+        public TlsConfig TlsConfig { get; }
+
+        public TlsSessionCacheConfig TlsSessionCacheConfig { get; }
+
+        public IReadOnlySet<string> RequiredHeaders => this.GetRequiredHeaders();
+
+        public static AlternatorConfigBuilder Builder()
+        {
+            return new AlternatorConfigBuilder();
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public static AlternatorConfigBuilder builder()
+        {
+            return Builder();
+        }
+#pragma warning restore SA1300, IDE1006
+
+        public IReadOnlySet<string> GetRequiredHeaders()
+        {
+            var required = new HashSet<string>(BaseRequiredHeaders, StringComparer.OrdinalIgnoreCase);
+            if (this.CompressionAlgorithm.IsEnabled())
+            {
+                required.UnionWith(CompressionHeaders);
+            }
+
+            if (this.UserAgentEnabled)
+            {
+                required.UnionWith(UserAgentHeaders);
+            }
+
+            if (this.AuthenticationEnabled)
+            {
+                required.UnionWith(AuthenticationHeaders);
+            }
+
+            return CreateReadOnlyHeaderSet(required);
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public IReadOnlyList<string> getSeedHosts()
+        {
+            return this.SeedHosts;
+        }
+
+        public string getScheme()
+        {
+            return this.Scheme;
+        }
+
+        public int getPort()
+        {
+            return this.Port;
+        }
+
+        public RoutingScope getRoutingScope()
+        {
+            return this.RoutingScope;
+        }
+
+        public RequestCompressionAlgorithm getCompressionAlgorithm()
+        {
+            return this.CompressionAlgorithm;
+        }
+
+        public int getMinCompressionSizeBytes()
+        {
+            return this.MinCompressionSizeBytes;
+        }
+
+        public bool isOptimizeHeaders()
+        {
+            return this.OptimizeHeaders;
+        }
+
+        public IReadOnlySet<string> getHeadersWhitelist()
+        {
+            return this.HeadersWhitelist;
+        }
+
+        public bool isUserAgentEnabled()
+        {
+            return this.UserAgentEnabled;
+        }
+
+        public bool isAuthenticationEnabled()
+        {
+            return this.AuthenticationEnabled;
+        }
+
+        public TlsSessionCacheConfig getTlsSessionCacheConfig()
+        {
+            return this.TlsSessionCacheConfig;
+        }
+
+        public TlsConfig getTlsConfig()
+        {
+            return this.TlsConfig;
+        }
+
+        public KeyRouteAffinityConfig? getKeyRouteAffinityConfig()
+        {
+            return this.KeyRouteAffinityConfig;
+        }
+
+        public long getActiveRefreshIntervalMs()
+        {
+            return this.ActiveRefreshIntervalMs;
+        }
+
+        public long getIdleRefreshIntervalMs()
+        {
+            return this.IdleRefreshIntervalMs;
+        }
+
+        public int getMaxConnections()
+        {
+            return this.MaxConnections;
+        }
+
+        public long getConnectionMaxIdleTimeMs()
+        {
+            return this.ConnectionMaxIdleTimeMs;
+        }
+
+        public long getConnectionTimeToLiveMs()
+        {
+            return this.ConnectionTimeToLiveMs;
+        }
+
+        public long getConnectionAcquisitionTimeoutMs()
+        {
+            return this.ConnectionAcquisitionTimeoutMs;
+        }
+
+        public long getConnectionTimeoutMs()
+        {
+            return this.ConnectionTimeoutMs;
+        }
+
+        public IReadOnlySet<string> getRequiredHeaders()
+        {
+            return this.GetRequiredHeaders();
+        }
+#pragma warning restore SA1300, IDE1006
+
+        internal static ReadOnlySet<string> CreateReadOnlyHeaderSet(IEnumerable<string> headers)
+        {
+            return new ReadOnlySet<string>(headers, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private IReadOnlySet<string> CreateHeadersWhitelist(ISet<string>? headersWhitelist)
+        {
+            if (headersWhitelist != null)
+            {
+                return CreateReadOnlyHeaderSet(headersWhitelist);
+            }
+
+            return this.GetRequiredHeaders();
+        }
+    }
+}

--- a/AlternatorConfigBuilder.cs
+++ b/AlternatorConfigBuilder.cs
@@ -1,0 +1,513 @@
+// <copyright file="AlternatorConfigBuilder.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    using ScyllaDB.Alternator.KeyRouting;
+    using ScyllaDB.Alternator.Routing;
+
+    public class AlternatorConfigBuilder
+    {
+        private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+
+        private readonly List<string> seedHosts = new List<string>();
+        private string scheme = string.Empty;
+        private int port = -1;
+        private RoutingScope? routingScope;
+        private RequestCompressionAlgorithm compressionAlgorithm = RequestCompressionAlgorithm.None;
+        private int minCompressionSizeBytes = AlternatorConfig.DefaultMinCompressionSizeBytes;
+        private bool optimizeHeaders;
+        private ISet<string>? headersWhitelist;
+        private bool headersWhitelistWasSet;
+        private bool userAgentEnabled = true;
+        private bool authenticationEnabledValue = true;
+        private KeyRouteAffinityConfig? keyRouteAffinityConfig;
+        private long activeRefreshIntervalMs = AlternatorConfig.DefaultActiveRefreshIntervalMs;
+        private long idleRefreshIntervalMs = AlternatorConfig.DefaultIdleRefreshIntervalMs;
+        private int maxConnections = AlternatorConfig.DefaultMaxConnections;
+        private long connectionMaxIdleTimeMs = AlternatorConfig.DefaultConnectionMaxIdleTimeMs;
+        private bool connectionMaxIdleTimeMsSet;
+        private long connectionTimeToLiveMs = AlternatorConfig.DefaultConnectionTimeToLiveMs;
+        private long connectionAcquisitionTimeoutMs = AlternatorConfig.DefaultConnectionAcquisitionTimeoutMs;
+        private long connectionTimeoutMs = AlternatorConfig.DefaultConnectionTimeoutMs;
+        private TlsSessionCacheConfig? tlsSessionCacheConfig;
+        private TlsConfig? tlsConfig;
+
+        public AlternatorConfigBuilder WithSeedNode(Uri? seedUri)
+        {
+            if (seedUri == null)
+            {
+                return this;
+            }
+
+            this.seedHosts.Clear();
+            this.seedHosts.Add(seedUri.Host);
+            this.scheme = seedUri.Scheme;
+            this.port = seedUri.Port;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithSeedNode(string? seedUri)
+        {
+            if (seedUri == null)
+            {
+                return this;
+            }
+
+            if (string.IsNullOrWhiteSpace(seedUri))
+            {
+                throw new ArgumentException("Seed URI cannot be null or empty.", nameof(seedUri));
+            }
+
+            return this.WithSeedNode(new Uri(seedUri));
+        }
+
+        public AlternatorConfigBuilder WithSeedHost(string? host)
+        {
+            if (host == null)
+            {
+                return this;
+            }
+
+            this.seedHosts.Clear();
+            this.seedHosts.Add(host);
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithSeedHosts(IEnumerable<string>? hosts)
+        {
+            if (hosts == null)
+            {
+                return this;
+            }
+
+            this.seedHosts.Clear();
+            this.seedHosts.AddRange(hosts);
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithScheme(string scheme)
+        {
+            this.scheme = scheme ?? string.Empty;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithPort(int port)
+        {
+            this.port = port;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithRoutingScope(RoutingScope? routingScope)
+        {
+            this.routingScope = routingScope;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithCompressionAlgorithm(RequestCompressionAlgorithm algorithm)
+        {
+            this.compressionAlgorithm = algorithm;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithCompressionAlgorithm(RequestCompressionAlgorithm? algorithm)
+        {
+            this.compressionAlgorithm = algorithm ?? RequestCompressionAlgorithm.None;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithMinCompressionSizeBytes(int minCompressionSizeBytes)
+        {
+            this.minCompressionSizeBytes = minCompressionSizeBytes;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithOptimizeHeaders(bool optimizeHeaders)
+        {
+            this.optimizeHeaders = optimizeHeaders;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithHeadersWhitelist(IEnumerable<string>? headers)
+        {
+            this.headersWhitelist = headers != null
+                ? new HashSet<string>(headers, StringComparer.OrdinalIgnoreCase)
+                : null;
+            this.headersWhitelistWasSet = true;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithUserAgentEnabled(bool userAgentEnabled)
+        {
+            this.userAgentEnabled = userAgentEnabled;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithAuthenticationEnabled(bool authenticationEnabled)
+        {
+            this.authenticationEnabledValue = authenticationEnabled;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithKeyRouteAffinity(KeyRouteAffinityConfig? keyRouteAffinityConfig)
+        {
+            this.keyRouteAffinityConfig = keyRouteAffinityConfig;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithKeyRouteAffinity(KeyRouteAffinity type)
+        {
+            this.keyRouteAffinityConfig = KeyRouteAffinityConfig.Of(type);
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithKeyRouteAffinity(KeyRouteAffinity? type)
+        {
+            this.keyRouteAffinityConfig = KeyRouteAffinityConfig.Of(type);
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithActiveRefreshIntervalMs(long intervalMs)
+        {
+            this.activeRefreshIntervalMs = intervalMs;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithIdleRefreshIntervalMs(long intervalMs)
+        {
+            this.idleRefreshIntervalMs = intervalMs;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithMaxConnections(int maxConnections)
+        {
+            this.maxConnections = maxConnections;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithConnectionMaxIdleTimeMs(long connectionMaxIdleTimeMs)
+        {
+            this.connectionMaxIdleTimeMs = connectionMaxIdleTimeMs;
+            this.connectionMaxIdleTimeMsSet = true;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithConnectionTimeToLiveMs(long connectionTimeToLiveMs)
+        {
+            this.connectionTimeToLiveMs = connectionTimeToLiveMs;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithConnectionAcquisitionTimeoutMs(long connectionAcquisitionTimeoutMs)
+        {
+            this.connectionAcquisitionTimeoutMs = connectionAcquisitionTimeoutMs;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithConnectionTimeoutMs(long connectionTimeoutMs)
+        {
+            this.connectionTimeoutMs = connectionTimeoutMs;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithTlsConfig(TlsConfig? tlsConfig)
+        {
+            this.tlsConfig = tlsConfig;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithTlsSessionCacheConfig(TlsSessionCacheConfig? tlsSessionCacheConfig)
+        {
+            this.tlsSessionCacheConfig = tlsSessionCacheConfig;
+            return this;
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public AlternatorConfigBuilder withSeedNode(Uri? seedUri)
+        {
+            return this.WithSeedNode(seedUri);
+        }
+
+        public AlternatorConfigBuilder withSeedNode(string? seedUri)
+        {
+            return this.WithSeedNode(seedUri);
+        }
+
+        public AlternatorConfigBuilder withSeedHost(string? host)
+        {
+            return this.WithSeedHost(host);
+        }
+
+        public AlternatorConfigBuilder withSeedHosts(IEnumerable<string>? hosts)
+        {
+            return this.WithSeedHosts(hosts);
+        }
+
+        public AlternatorConfigBuilder withScheme(string scheme)
+        {
+            return this.WithScheme(scheme);
+        }
+
+        public AlternatorConfigBuilder withPort(int port)
+        {
+            return this.WithPort(port);
+        }
+
+        public AlternatorConfigBuilder withRoutingScope(RoutingScope? routingScope)
+        {
+            return this.WithRoutingScope(routingScope);
+        }
+
+        public AlternatorConfigBuilder withCompressionAlgorithm(RequestCompressionAlgorithm algorithm)
+        {
+            return this.WithCompressionAlgorithm(algorithm);
+        }
+
+        public AlternatorConfigBuilder withCompressionAlgorithm(RequestCompressionAlgorithm? algorithm)
+        {
+            return this.WithCompressionAlgorithm(algorithm);
+        }
+
+        public AlternatorConfigBuilder withMinCompressionSizeBytes(int minCompressionSizeBytes)
+        {
+            return this.WithMinCompressionSizeBytes(minCompressionSizeBytes);
+        }
+
+        public AlternatorConfigBuilder withOptimizeHeaders(bool optimizeHeaders)
+        {
+            return this.WithOptimizeHeaders(optimizeHeaders);
+        }
+
+        public AlternatorConfigBuilder withHeadersWhitelist(IEnumerable<string>? headers)
+        {
+            return this.WithHeadersWhitelist(headers);
+        }
+
+        public AlternatorConfigBuilder withUserAgentEnabled(bool userAgentEnabled)
+        {
+            return this.WithUserAgentEnabled(userAgentEnabled);
+        }
+
+        public AlternatorConfigBuilder withAuthenticationEnabled(bool authenticationEnabled)
+        {
+            return this.WithAuthenticationEnabled(authenticationEnabled);
+        }
+
+        public AlternatorConfigBuilder authenticationEnabled(bool authenticationEnabled)
+        {
+            return this.WithAuthenticationEnabled(authenticationEnabled);
+        }
+
+        public AlternatorConfigBuilder withKeyRouteAffinity(KeyRouteAffinityConfig? keyRouteAffinityConfig)
+        {
+            return this.WithKeyRouteAffinity(keyRouteAffinityConfig);
+        }
+
+        public AlternatorConfigBuilder withKeyRouteAffinity(KeyRouteAffinity type)
+        {
+            return this.WithKeyRouteAffinity(type);
+        }
+
+        public AlternatorConfigBuilder withKeyRouteAffinity(KeyRouteAffinity? type)
+        {
+            return this.WithKeyRouteAffinity(type);
+        }
+
+        public ISet<string> getRequiredHeaders()
+        {
+            return this.GetRequiredHeaders();
+        }
+
+        public AlternatorConfigBuilder withTlsConfig(TlsConfig? tlsConfig)
+        {
+            return this.WithTlsConfig(tlsConfig);
+        }
+
+        public AlternatorConfigBuilder withTlsSessionCacheConfig(TlsSessionCacheConfig? tlsSessionCacheConfig)
+        {
+            return this.WithTlsSessionCacheConfig(tlsSessionCacheConfig);
+        }
+
+        public AlternatorConfigBuilder withActiveRefreshIntervalMs(long intervalMs)
+        {
+            return this.WithActiveRefreshIntervalMs(intervalMs);
+        }
+
+        public AlternatorConfigBuilder withIdleRefreshIntervalMs(long intervalMs)
+        {
+            return this.WithIdleRefreshIntervalMs(intervalMs);
+        }
+
+        public AlternatorConfigBuilder withMaxConnections(int maxConnections)
+        {
+            return this.WithMaxConnections(maxConnections);
+        }
+
+        public AlternatorConfigBuilder withConnectionMaxIdleTimeMs(long connectionMaxIdleTimeMs)
+        {
+            return this.WithConnectionMaxIdleTimeMs(connectionMaxIdleTimeMs);
+        }
+
+        public AlternatorConfigBuilder withConnectionTimeToLiveMs(long connectionTimeToLiveMs)
+        {
+            return this.WithConnectionTimeToLiveMs(connectionTimeToLiveMs);
+        }
+
+        public AlternatorConfigBuilder withConnectionAcquisitionTimeoutMs(long connectionAcquisitionTimeoutMs)
+        {
+            return this.WithConnectionAcquisitionTimeoutMs(connectionAcquisitionTimeoutMs);
+        }
+
+        public AlternatorConfigBuilder withConnectionTimeoutMs(long connectionTimeoutMs)
+        {
+            return this.WithConnectionTimeoutMs(connectionTimeoutMs);
+        }
+
+        public AlternatorConfig build()
+        {
+            return this.Build();
+        }
+#pragma warning restore SA1300, IDE1006
+
+        public ISet<string> GetRequiredHeaders()
+        {
+            var required = new HashSet<string>(AlternatorConfig.BaseRequiredHeaders, StringComparer.OrdinalIgnoreCase);
+            if (this.compressionAlgorithm.IsEnabled())
+            {
+                required.UnionWith(AlternatorConfig.CompressionHeaders);
+            }
+
+            if (this.userAgentEnabled)
+            {
+                required.UnionWith(AlternatorConfig.UserAgentHeaders);
+            }
+
+            if (this.authenticationEnabledValue)
+            {
+                required.UnionWith(AlternatorConfig.AuthenticationHeaders);
+            }
+
+            return AlternatorConfig.CreateReadOnlyHeaderSet(required);
+        }
+
+        public AlternatorConfig Build()
+        {
+            this.ValidateScalarOptions();
+
+            if (this.headersWhitelistWasSet)
+            {
+                this.ValidateHeadersWhitelist();
+            }
+
+            if (this.connectionMaxIdleTimeMsSet && this.connectionMaxIdleTimeMs == 0)
+            {
+                Logger.Warn(
+                    "connectionMaxIdleTimeMs is set to 0, which disables idle connection eviction. This can lead to stale connections in long-running applications.");
+            }
+
+            var effectiveTlsConfig = this.CreateEffectiveTlsConfig();
+            return new AlternatorConfig(
+                new List<string>(this.seedHosts),
+                this.scheme,
+                this.port,
+                this.routingScope ?? ClusterScope.Create(),
+                this.compressionAlgorithm,
+                this.minCompressionSizeBytes,
+                this.optimizeHeaders,
+                this.headersWhitelist,
+                this.userAgentEnabled,
+                this.authenticationEnabledValue,
+                this.keyRouteAffinityConfig,
+                this.activeRefreshIntervalMs,
+                this.idleRefreshIntervalMs,
+                this.maxConnections,
+                this.connectionMaxIdleTimeMs,
+                this.connectionTimeToLiveMs,
+                this.connectionAcquisitionTimeoutMs,
+                this.connectionTimeoutMs,
+                this.tlsSessionCacheConfig,
+                effectiveTlsConfig);
+        }
+
+        private TlsConfig CreateEffectiveTlsConfig()
+        {
+            if (this.tlsConfig != null)
+            {
+                return this.tlsConfig;
+            }
+
+            if (this.tlsSessionCacheConfig != null)
+            {
+                return TlsConfig.Builder()
+                    .WithTrustAllCertificates(true)
+                    .WithSessionCacheConfig(this.tlsSessionCacheConfig)
+                    .Build();
+            }
+
+            return TlsConfig.TrustAll();
+        }
+
+        private void ValidateScalarOptions()
+        {
+            if (this.minCompressionSizeBytes < 0)
+            {
+                throw new ArgumentException(
+                    "minCompressionSizeBytes must be non-negative, but was: " + this.minCompressionSizeBytes,
+                    nameof(this.minCompressionSizeBytes));
+            }
+
+            if (this.maxConnections <= 0)
+            {
+                throw new ArgumentException(
+                    "maxConnections must be positive, but was: " + this.maxConnections,
+                    nameof(this.maxConnections));
+            }
+
+            if (this.connectionMaxIdleTimeMs < 0)
+            {
+                throw new ArgumentException(
+                    "connectionMaxIdleTimeMs must be non-negative, but was: " + this.connectionMaxIdleTimeMs,
+                    nameof(this.connectionMaxIdleTimeMs));
+            }
+
+            if (this.connectionTimeToLiveMs < 0)
+            {
+                throw new ArgumentException(
+                    "connectionTimeToLiveMs must be non-negative, but was: " + this.connectionTimeToLiveMs,
+                    nameof(this.connectionTimeToLiveMs));
+            }
+
+            if (this.connectionAcquisitionTimeoutMs < 0)
+            {
+                throw new ArgumentException(
+                    "connectionAcquisitionTimeoutMs must be non-negative, but was: " + this.connectionAcquisitionTimeoutMs,
+                    nameof(this.connectionAcquisitionTimeoutMs));
+            }
+
+            if (this.connectionTimeoutMs < 0)
+            {
+                throw new ArgumentException(
+                    "connectionTimeoutMs must be non-negative, but was: " + this.connectionTimeoutMs,
+                    nameof(this.connectionTimeoutMs));
+            }
+        }
+
+        private void ValidateHeadersWhitelist()
+        {
+            if (this.headersWhitelist == null || this.headersWhitelist.Count == 0)
+            {
+                throw new ArgumentException("Headers whitelist cannot be null or empty. To disable optimization, use WithOptimizeHeaders(false).", nameof(this.headersWhitelist));
+            }
+
+            var missing = new HashSet<string>(this.GetRequiredHeaders(), StringComparer.OrdinalIgnoreCase);
+            missing.ExceptWith(this.headersWhitelist);
+            if (missing.Count != 0)
+            {
+                throw new ArgumentException(
+                    "Custom headers whitelist is missing required headers: " + string.Join(", ", missing),
+                    nameof(this.headersWhitelist));
+            }
+        }
+    }
+}

--- a/HttpClientType.cs
+++ b/HttpClientType.cs
@@ -1,0 +1,23 @@
+// <copyright file="HttpClientType.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    public enum HttpClientType
+    {
+        Auto = 0,
+        SystemNetHttp = 1,
+        Apache = 2,
+        Crt = 3,
+        Netty = 4,
+
+#pragma warning disable SA1300, IDE1006
+        AUTO = Auto,
+        SYSTEM_NET_HTTP = SystemNetHttp,
+        APACHE = Apache,
+        CRT = Crt,
+        NETTY = Netty,
+#pragma warning restore SA1300, IDE1006
+    }
+}

--- a/HttpClientTypeExtensions.cs
+++ b/HttpClientTypeExtensions.cs
@@ -1,0 +1,39 @@
+// <copyright file="HttpClientTypeExtensions.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    public static class HttpClientTypeExtensions
+    {
+        public static bool SupportsSync(this HttpClientType httpClientType)
+        {
+            return httpClientType switch
+            {
+                HttpClientType.Netty => false,
+                _ => true,
+            };
+        }
+
+        public static bool SupportsAsync(this HttpClientType httpClientType)
+        {
+            return httpClientType switch
+            {
+                HttpClientType.Apache => false,
+                _ => true,
+            };
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public static bool supportsSync(this HttpClientType httpClientType)
+        {
+            return httpClientType.SupportsSync();
+        }
+
+        public static bool supportsAsync(this HttpClientType httpClientType)
+        {
+            return httpClientType.SupportsAsync();
+        }
+#pragma warning restore SA1300, IDE1006
+    }
+}

--- a/KeyRouting/KeyRouteAffinity.cs
+++ b/KeyRouting/KeyRouteAffinity.cs
@@ -1,0 +1,19 @@
+// <copyright file="KeyRouteAffinity.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator.KeyRouting
+{
+    public enum KeyRouteAffinity
+    {
+        None = 0,
+        Rmw = 1,
+        AnyWrite = 2,
+
+#pragma warning disable SA1300, IDE1006
+        NONE = None,
+        RMW = Rmw,
+        ANY_WRITE = AnyWrite,
+#pragma warning restore SA1300, IDE1006
+    }
+}

--- a/KeyRouting/KeyRouteAffinityConfig.cs
+++ b/KeyRouting/KeyRouteAffinityConfig.cs
@@ -1,0 +1,66 @@
+// <copyright file="KeyRouteAffinityConfig.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator.KeyRouting
+{
+    using System.Collections.ObjectModel;
+
+    public sealed class KeyRouteAffinityConfig
+    {
+        private KeyRouteAffinityConfig(KeyRouteAffinity type, IDictionary<string, string> pkInfoPerTable)
+        {
+            this.Type = type;
+            this.PkInfoPerTable = new ReadOnlyDictionary<string, string>(
+                new Dictionary<string, string>(pkInfoPerTable, StringComparer.Ordinal));
+        }
+
+        public KeyRouteAffinity Type { get; }
+
+        public IReadOnlyDictionary<string, string> PkInfoPerTable { get; }
+
+        public bool IsEnabled => this.Type != KeyRouteAffinity.None;
+
+        public static KeyRouteAffinityConfigBuilder Builder()
+        {
+            return new KeyRouteAffinityConfigBuilder();
+        }
+
+        public static KeyRouteAffinityConfig Of(KeyRouteAffinity? type)
+        {
+            return new KeyRouteAffinityConfig(type ?? KeyRouteAffinity.None, new Dictionary<string, string>());
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public static KeyRouteAffinityConfigBuilder builder()
+        {
+            return Builder();
+        }
+
+        public static KeyRouteAffinityConfig of(KeyRouteAffinity? type)
+        {
+            return Of(type);
+        }
+
+        public KeyRouteAffinity getType()
+        {
+            return this.Type;
+        }
+
+        public IReadOnlyDictionary<string, string> getPkInfoPerTable()
+        {
+            return this.PkInfoPerTable;
+        }
+
+        public bool isEnabled()
+        {
+            return this.IsEnabled;
+        }
+#pragma warning restore SA1300, IDE1006
+
+        internal static KeyRouteAffinityConfig Create(KeyRouteAffinity type, IDictionary<string, string> pkInfoPerTable)
+        {
+            return new KeyRouteAffinityConfig(type, pkInfoPerTable);
+        }
+    }
+}

--- a/KeyRouting/KeyRouteAffinityConfigBuilder.cs
+++ b/KeyRouting/KeyRouteAffinityConfigBuilder.cs
@@ -1,0 +1,68 @@
+// <copyright file="KeyRouteAffinityConfigBuilder.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator.KeyRouting
+{
+    public sealed class KeyRouteAffinityConfigBuilder
+    {
+        private readonly Dictionary<string, string> pkInfoPerTable = new Dictionary<string, string>(StringComparer.Ordinal);
+        private KeyRouteAffinity type = KeyRouteAffinity.None;
+
+        public KeyRouteAffinityConfigBuilder WithType(KeyRouteAffinity? type)
+        {
+            this.type = type ?? KeyRouteAffinity.None;
+            return this;
+        }
+
+        public KeyRouteAffinityConfigBuilder WithPkInfo(string tableName, string pkAttributeName)
+        {
+            if (tableName != null && pkAttributeName != null)
+            {
+                this.pkInfoPerTable[tableName] = pkAttributeName;
+            }
+
+            return this;
+        }
+
+        public KeyRouteAffinityConfigBuilder WithPkInfoMap(IDictionary<string, string> pkInfo)
+        {
+            if (pkInfo != null)
+            {
+                foreach (var item in pkInfo)
+                {
+                    this.pkInfoPerTable[item.Key] = item.Value;
+                }
+            }
+
+            return this;
+        }
+
+        public KeyRouteAffinityConfig Build()
+        {
+            return KeyRouteAffinityConfig.Create(this.type, this.pkInfoPerTable);
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public KeyRouteAffinityConfigBuilder withType(KeyRouteAffinity? type)
+        {
+            return this.WithType(type);
+        }
+
+        public KeyRouteAffinityConfigBuilder withPkInfo(string tableName, string pkAttributeName)
+        {
+            return this.WithPkInfo(tableName, pkAttributeName);
+        }
+
+        public KeyRouteAffinityConfigBuilder withPkInfoMap(IDictionary<string, string> pkInfo)
+        {
+            return this.WithPkInfoMap(pkInfo);
+        }
+
+        public KeyRouteAffinityConfig build()
+        {
+            return this.Build();
+        }
+#pragma warning restore SA1300, IDE1006
+    }
+}

--- a/ReadOnlySet.cs
+++ b/ReadOnlySet.cs
@@ -1,0 +1,110 @@
+// <copyright file="ReadOnlySet.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    internal sealed class ReadOnlySet<T> : ISet<T>, IReadOnlySet<T>
+    {
+        private readonly HashSet<T> items;
+
+        public ReadOnlySet(IEnumerable<T> items, IEqualityComparer<T>? comparer = null)
+        {
+            this.items = new HashSet<T>(items, comparer);
+        }
+
+        public int Count => this.items.Count;
+
+        public bool IsReadOnly => true;
+
+        bool ISet<T>.Add(T item)
+        {
+            throw new NotSupportedException("This set is read-only.");
+        }
+
+        public void Add(T item)
+        {
+            throw new NotSupportedException("This set is read-only.");
+        }
+
+        public void ExceptWith(IEnumerable<T> other)
+        {
+            throw new NotSupportedException("This set is read-only.");
+        }
+
+        public void IntersectWith(IEnumerable<T> other)
+        {
+            throw new NotSupportedException("This set is read-only.");
+        }
+
+        public bool IsProperSubsetOf(IEnumerable<T> other)
+        {
+            return this.items.IsProperSubsetOf(other);
+        }
+
+        public bool IsProperSupersetOf(IEnumerable<T> other)
+        {
+            return this.items.IsProperSupersetOf(other);
+        }
+
+        public bool IsSubsetOf(IEnumerable<T> other)
+        {
+            return this.items.IsSubsetOf(other);
+        }
+
+        public bool IsSupersetOf(IEnumerable<T> other)
+        {
+            return this.items.IsSupersetOf(other);
+        }
+
+        public bool Overlaps(IEnumerable<T> other)
+        {
+            return this.items.Overlaps(other);
+        }
+
+        public bool SetEquals(IEnumerable<T> other)
+        {
+            return this.items.SetEquals(other);
+        }
+
+        public void SymmetricExceptWith(IEnumerable<T> other)
+        {
+            throw new NotSupportedException("This set is read-only.");
+        }
+
+        public void UnionWith(IEnumerable<T> other)
+        {
+            throw new NotSupportedException("This set is read-only.");
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException("This set is read-only.");
+        }
+
+        public bool Contains(T item)
+        {
+            return this.items.Contains(item);
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            this.items.CopyTo(array, arrayIndex);
+        }
+
+        public bool Remove(T item)
+        {
+            throw new NotSupportedException("This set is read-only.");
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return this.items.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/RequestCompressionAlgorithm.cs
+++ b/RequestCompressionAlgorithm.cs
@@ -1,0 +1,17 @@
+// <copyright file="RequestCompressionAlgorithm.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    public enum RequestCompressionAlgorithm
+    {
+        None = 0,
+        Gzip = 1,
+
+#pragma warning disable SA1300, IDE1006
+        NONE = None,
+        GZIP = Gzip,
+#pragma warning restore SA1300, IDE1006
+    }
+}

--- a/RequestCompressionAlgorithmExtensions.cs
+++ b/RequestCompressionAlgorithmExtensions.cs
@@ -1,0 +1,21 @@
+// <copyright file="RequestCompressionAlgorithmExtensions.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    public static class RequestCompressionAlgorithmExtensions
+    {
+        public static bool IsEnabled(this RequestCompressionAlgorithm algorithm)
+        {
+            return algorithm != RequestCompressionAlgorithm.None;
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public static bool isEnabled(this RequestCompressionAlgorithm algorithm)
+        {
+            return algorithm.IsEnabled();
+        }
+#pragma warning restore SA1300, IDE1006
+    }
+}

--- a/Routing/ClusterScope.cs
+++ b/Routing/ClusterScope.cs
@@ -1,0 +1,70 @@
+// <copyright file="ClusterScope.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator.Routing
+{
+    public sealed class ClusterScope : RoutingScope
+    {
+        private static readonly ClusterScope Instance = new ClusterScope();
+
+        private ClusterScope()
+        {
+        }
+
+        public string Name => "Cluster";
+
+        public string Description => "Cluster (all nodes)";
+
+        public RoutingScope? Fallback => null;
+
+        public string LocalNodesQuery => string.Empty;
+
+        public static ClusterScope Create()
+        {
+            return Instance;
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public static ClusterScope create()
+        {
+            return Create();
+        }
+
+        public string getName()
+        {
+            return this.Name;
+        }
+
+        public string getDescription()
+        {
+            return this.Description;
+        }
+
+        public RoutingScope? getFallback()
+        {
+            return this.Fallback;
+        }
+
+        public string getLocalNodesQuery()
+        {
+            return this.LocalNodesQuery;
+        }
+#pragma warning restore SA1300, IDE1006
+
+        public override string ToString()
+        {
+            return "ClusterScope{}";
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is ClusterScope;
+        }
+
+        public override int GetHashCode()
+        {
+            return typeof(ClusterScope).GetHashCode();
+        }
+    }
+}

--- a/Routing/DatacenterScope.cs
+++ b/Routing/DatacenterScope.cs
@@ -1,0 +1,84 @@
+// <copyright file="DatacenterScope.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator.Routing
+{
+    public sealed class DatacenterScope : RoutingScope
+    {
+        private DatacenterScope(string datacenter, RoutingScope? fallback)
+        {
+            if (string.IsNullOrEmpty(datacenter))
+            {
+                throw new ArgumentException("datacenter cannot be null or empty", nameof(datacenter));
+            }
+
+            this.Datacenter = datacenter;
+            this.Fallback = fallback;
+        }
+
+        public string Datacenter { get; }
+
+        public string Name => "Datacenter";
+
+        public string Description => $"Datacenter {this.Datacenter}";
+
+        public RoutingScope? Fallback { get; }
+
+        public string LocalNodesQuery => $"dc={this.Datacenter}";
+
+        public static DatacenterScope Of(string datacenter, RoutingScope? fallback)
+        {
+            return new DatacenterScope(datacenter, fallback);
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public static DatacenterScope of(string datacenter, RoutingScope? fallback)
+        {
+            return Of(datacenter, fallback);
+        }
+
+        public string getDatacenter()
+        {
+            return this.Datacenter;
+        }
+
+        public string getName()
+        {
+            return this.Name;
+        }
+
+        public string getDescription()
+        {
+            return this.Description;
+        }
+
+        public RoutingScope? getFallback()
+        {
+            return this.Fallback;
+        }
+
+        public string getLocalNodesQuery()
+        {
+            return this.LocalNodesQuery;
+        }
+#pragma warning restore SA1300, IDE1006
+
+        public override string ToString()
+        {
+            return $"DatacenterScope{{datacenter='{this.Datacenter}', fallback={this.Fallback?.ToString() ?? "null"}}}";
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is DatacenterScope other
+                && string.Equals(this.Datacenter, other.Datacenter, StringComparison.Ordinal)
+                && EqualityComparer<RoutingScope?>.Default.Equals(this.Fallback, other.Fallback);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(this.Datacenter, this.Fallback);
+        }
+    }
+}

--- a/Routing/RackScope.cs
+++ b/Routing/RackScope.cs
@@ -1,0 +1,99 @@
+// <copyright file="RackScope.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator.Routing
+{
+    public sealed class RackScope : RoutingScope
+    {
+        private RackScope(string datacenter, string rack, RoutingScope? fallback)
+        {
+            if (string.IsNullOrEmpty(datacenter))
+            {
+                throw new ArgumentException("datacenter cannot be null or empty", nameof(datacenter));
+            }
+
+            if (string.IsNullOrEmpty(rack))
+            {
+                throw new ArgumentException("rack cannot be null or empty", nameof(rack));
+            }
+
+            this.Datacenter = datacenter;
+            this.Rack = rack;
+            this.Fallback = fallback;
+        }
+
+        public string Datacenter { get; }
+
+        public string Rack { get; }
+
+        public string Name => "Rack";
+
+        public string Description => $"Rack {this.Rack} in Datacenter {this.Datacenter}";
+
+        public RoutingScope? Fallback { get; }
+
+        public string LocalNodesQuery =>
+            $"dc={this.Datacenter}&rack={this.Rack}";
+
+        public static RackScope Of(string datacenter, string rack, RoutingScope? fallback)
+        {
+            return new RackScope(datacenter, rack, fallback);
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public static RackScope of(string datacenter, string rack, RoutingScope? fallback)
+        {
+            return Of(datacenter, rack, fallback);
+        }
+
+        public string getDatacenter()
+        {
+            return this.Datacenter;
+        }
+
+        public string getRack()
+        {
+            return this.Rack;
+        }
+
+        public string getName()
+        {
+            return this.Name;
+        }
+
+        public string getDescription()
+        {
+            return this.Description;
+        }
+
+        public RoutingScope? getFallback()
+        {
+            return this.Fallback;
+        }
+
+        public string getLocalNodesQuery()
+        {
+            return this.LocalNodesQuery;
+        }
+#pragma warning restore SA1300, IDE1006
+
+        public override string ToString()
+        {
+            return $"RackScope{{datacenter='{this.Datacenter}', rack='{this.Rack}', fallback={this.Fallback?.ToString() ?? "null"}}}";
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is RackScope other
+                && string.Equals(this.Datacenter, other.Datacenter, StringComparison.Ordinal)
+                && string.Equals(this.Rack, other.Rack, StringComparison.Ordinal)
+                && EqualityComparer<RoutingScope?>.Default.Equals(this.Fallback, other.Fallback);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(this.Datacenter, this.Rack, this.Fallback);
+        }
+    }
+}

--- a/Routing/RoutingScope.cs
+++ b/Routing/RoutingScope.cs
@@ -1,0 +1,41 @@
+// <copyright file="RoutingScope.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator.Routing
+{
+#pragma warning disable SA1302
+    public interface RoutingScope
+    {
+        string Name { get; }
+
+        string Description { get; }
+
+        RoutingScope? Fallback { get; }
+
+        string LocalNodesQuery { get; }
+
+#pragma warning disable SA1300, IDE1006
+        string getName()
+        {
+            return this.Name;
+        }
+
+        string getDescription()
+        {
+            return this.Description;
+        }
+
+        RoutingScope? getFallback()
+        {
+            return this.Fallback;
+        }
+
+        string getLocalNodesQuery()
+        {
+            return this.LocalNodesQuery;
+        }
+#pragma warning restore SA1300, IDE1006
+    }
+#pragma warning restore SA1302
+}

--- a/TlsConfig.cs
+++ b/TlsConfig.cs
@@ -1,0 +1,184 @@
+// <copyright file="TlsConfig.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    public sealed class TlsConfig
+    {
+        private static readonly TlsConfig TrustAllInstance = new TlsConfig(
+            new List<string>(),
+            null,
+            null,
+            false,
+            true,
+            false,
+            TlsSessionCacheConfig.GetDefault());
+
+        private static readonly TlsConfig SystemDefaultInstance = new TlsConfig(
+            new List<string>(),
+            null,
+            null,
+            true,
+            false,
+            true,
+            TlsSessionCacheConfig.GetDefault());
+
+        internal TlsConfig(
+            IReadOnlyList<string> customCaCertPaths,
+            string? clientCertificatePath,
+            string? clientPrivateKeyPath,
+            bool trustSystemCaCerts,
+            bool trustAllCertificates,
+            bool verifyHostname,
+            TlsSessionCacheConfig sessionCacheConfig)
+        {
+            this.CustomCaCertPaths = new List<string>(customCaCertPaths ?? Array.Empty<string>()).AsReadOnly();
+            this.ClientCertificatePath = clientCertificatePath;
+            this.ClientPrivateKeyPath = clientPrivateKeyPath;
+            this.TrustSystemCaCerts = trustSystemCaCerts;
+            this.TrustAllCertificates = trustAllCertificates;
+            this.VerifyHostname = verifyHostname;
+            this.SessionCacheConfig = sessionCacheConfig ?? TlsSessionCacheConfig.GetDefault();
+        }
+
+        public IReadOnlyList<string> CustomCaCertPaths { get; }
+
+        public string? ClientCertificatePath { get; }
+
+        public string? ClientPrivateKeyPath { get; }
+
+        public bool HasClientCertificate => this.ClientCertificatePath != null && this.ClientPrivateKeyPath != null;
+
+        public bool TrustSystemCaCerts { get; }
+
+        public bool TrustAllCertificates { get; }
+
+        public bool VerifyHostname { get; }
+
+        public TlsSessionCacheConfig SessionCacheConfig { get; }
+
+        public static TlsConfig TrustAll()
+        {
+            return TrustAllInstance;
+        }
+
+        public static TlsConfig SystemDefault()
+        {
+            return SystemDefaultInstance;
+        }
+
+        public static TlsConfigBuilder Builder()
+        {
+            return new TlsConfigBuilder();
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public static TlsConfig trustAll()
+        {
+            return TrustAll();
+        }
+
+        public static TlsConfig systemDefault()
+        {
+            return SystemDefault();
+        }
+
+        public static TlsConfigBuilder builder()
+        {
+            return Builder();
+        }
+
+        public IReadOnlyList<string> getCustomCaCertPaths()
+        {
+            return this.CustomCaCertPaths;
+        }
+
+        public string? getClientCertificatePath()
+        {
+            return this.ClientCertificatePath;
+        }
+
+        public string? getClientPrivateKeyPath()
+        {
+            return this.ClientPrivateKeyPath;
+        }
+
+        public bool hasClientCertificate()
+        {
+            return this.HasClientCertificate;
+        }
+
+        public bool isTrustSystemCaCerts()
+        {
+            return this.TrustSystemCaCerts;
+        }
+
+        public bool isTrustAllCertificates()
+        {
+            return this.TrustAllCertificates;
+        }
+
+        public bool isVerifyHostname()
+        {
+            return this.VerifyHostname;
+        }
+
+        public TlsSessionCacheConfig getSessionCacheConfig()
+        {
+            return this.SessionCacheConfig;
+        }
+#pragma warning restore SA1300, IDE1006
+
+        public override string ToString()
+        {
+            return "TlsConfig{"
+                + "customCaCertPaths="
+                + "["
+                + string.Join(", ", this.CustomCaCertPaths)
+                + "]"
+                + ", clientCertificatePath="
+                + (this.ClientCertificatePath ?? "null")
+                + ", clientPrivateKeyPath="
+                + (this.ClientPrivateKeyPath ?? "null")
+                + ", trustSystemCaCerts="
+                + this.TrustSystemCaCerts.ToString().ToLowerInvariant()
+                + ", trustAllCertificates="
+                + this.TrustAllCertificates.ToString().ToLowerInvariant()
+                + ", verifyHostname="
+                + this.VerifyHostname.ToString().ToLowerInvariant()
+                + ", sessionCacheConfig="
+                + this.SessionCacheConfig
+                + "}";
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is TlsConfig other
+                && this.TrustSystemCaCerts == other.TrustSystemCaCerts
+                && this.TrustAllCertificates == other.TrustAllCertificates
+                && this.VerifyHostname == other.VerifyHostname
+                && this.CustomCaCertPaths.SequenceEqual(other.CustomCaCertPaths)
+                && string.Equals(this.ClientCertificatePath, other.ClientCertificatePath, StringComparison.Ordinal)
+                && string.Equals(this.ClientPrivateKeyPath, other.ClientPrivateKeyPath, StringComparison.Ordinal)
+                && Equals(this.SessionCacheConfig, other.SessionCacheConfig);
+        }
+
+        public override int GetHashCode()
+        {
+            var hash = default(HashCode);
+            foreach (var path in this.CustomCaCertPaths)
+            {
+                hash.Add(path, StringComparer.Ordinal);
+            }
+
+            hash.Add(this.ClientCertificatePath, StringComparer.Ordinal);
+            hash.Add(this.ClientPrivateKeyPath, StringComparer.Ordinal);
+            hash.Add(this.TrustSystemCaCerts);
+            hash.Add(this.TrustAllCertificates);
+            hash.Add(this.VerifyHostname);
+            hash.Add(this.SessionCacheConfig);
+            return hash.ToHashCode();
+        }
+    }
+}

--- a/TlsConfigBuilder.cs
+++ b/TlsConfigBuilder.cs
@@ -1,0 +1,146 @@
+// <copyright file="TlsConfigBuilder.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    public sealed class TlsConfigBuilder
+    {
+        private List<string> customCaCertPaths = new List<string>();
+        private string? clientCertificatePath;
+        private string? clientPrivateKeyPath;
+        private bool trustSystemCaCerts = true;
+        private bool trustAllCertificates;
+        private bool verifyHostname = true;
+        private TlsSessionCacheConfig sessionCacheConfig = TlsSessionCacheConfig.GetDefault();
+
+        public TlsConfigBuilder WithCaCertPath(string? path)
+        {
+            if (path == null)
+            {
+                throw new ArgumentException("CA certificate path cannot be null", nameof(path));
+            }
+
+            this.customCaCertPaths.Add(path);
+            return this;
+        }
+
+        public TlsConfigBuilder WithCaCertPaths(IEnumerable<string>? paths)
+        {
+            if (paths == null)
+            {
+                this.customCaCertPaths = new List<string>();
+                return this;
+            }
+
+            this.customCaCertPaths = new List<string>();
+            foreach (var path in paths)
+            {
+                this.WithCaCertPath(path);
+            }
+
+            return this;
+        }
+
+        public TlsConfigBuilder WithClientCertificate(string? certificatePath, string? privateKeyPath)
+        {
+            if (certificatePath == null)
+            {
+                throw new ArgumentException("Client certificate path cannot be null", nameof(certificatePath));
+            }
+
+            if (privateKeyPath == null)
+            {
+                throw new ArgumentException("Client private key path cannot be null", nameof(privateKeyPath));
+            }
+
+            this.clientCertificatePath = certificatePath;
+            this.clientPrivateKeyPath = privateKeyPath;
+            return this;
+        }
+
+        public TlsConfigBuilder WithTrustSystemCaCerts(bool trustSystemCaCerts)
+        {
+            this.trustSystemCaCerts = trustSystemCaCerts;
+            return this;
+        }
+
+        public TlsConfigBuilder WithTrustAllCertificates(bool trustAllCertificates)
+        {
+            this.trustAllCertificates = trustAllCertificates;
+            return this;
+        }
+
+        public TlsConfigBuilder WithVerifyHostname(bool verifyHostname)
+        {
+            this.verifyHostname = verifyHostname;
+            return this;
+        }
+
+        public TlsConfigBuilder WithSessionCacheConfig(TlsSessionCacheConfig? sessionCacheConfig)
+        {
+            this.sessionCacheConfig = sessionCacheConfig ?? TlsSessionCacheConfig.GetDefault();
+            return this;
+        }
+
+        public TlsConfig Build()
+        {
+            if (!this.trustAllCertificates && !this.trustSystemCaCerts && this.customCaCertPaths.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    "Invalid TLS configuration: no trust source configured. Either enable trustSystemCaCerts, add custom CA certificates, or enable trustAllCertificates (for development only).");
+            }
+
+            return new TlsConfig(
+                this.customCaCertPaths.AsReadOnly(),
+                this.clientCertificatePath,
+                this.clientPrivateKeyPath,
+                this.trustSystemCaCerts,
+                this.trustAllCertificates,
+                this.trustAllCertificates ? false : this.verifyHostname,
+                this.sessionCacheConfig);
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public TlsConfigBuilder withCaCertPath(string? path)
+        {
+            return this.WithCaCertPath(path);
+        }
+
+        public TlsConfigBuilder withCaCertPaths(IEnumerable<string>? paths)
+        {
+            return this.WithCaCertPaths(paths);
+        }
+
+        public TlsConfigBuilder withClientCertificate(string? certificatePath, string? privateKeyPath)
+        {
+            return this.WithClientCertificate(certificatePath, privateKeyPath);
+        }
+
+        public TlsConfigBuilder withTrustSystemCaCerts(bool trustSystemCaCerts)
+        {
+            return this.WithTrustSystemCaCerts(trustSystemCaCerts);
+        }
+
+        public TlsConfigBuilder withTrustAllCertificates(bool trustAllCertificates)
+        {
+            return this.WithTrustAllCertificates(trustAllCertificates);
+        }
+
+        public TlsConfigBuilder withVerifyHostname(bool verifyHostname)
+        {
+            return this.WithVerifyHostname(verifyHostname);
+        }
+
+        public TlsConfigBuilder withSessionCacheConfig(TlsSessionCacheConfig? sessionCacheConfig)
+        {
+            return this.WithSessionCacheConfig(sessionCacheConfig);
+        }
+
+        public TlsConfig build()
+        {
+            return this.Build();
+        }
+#pragma warning restore SA1300, IDE1006
+    }
+}

--- a/TlsSessionCacheConfig.cs
+++ b/TlsSessionCacheConfig.cs
@@ -1,0 +1,113 @@
+// <copyright file="TlsSessionCacheConfig.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    public sealed class TlsSessionCacheConfig
+    {
+        public const int DefaultSessionCacheSize = 1024;
+        public const int DefaultSessionTimeoutSeconds = 86400;
+
+#pragma warning disable SA1310, IDE1006
+        public const int DEFAULT_SESSION_CACHE_SIZE = DefaultSessionCacheSize;
+        public const int DEFAULT_SESSION_TIMEOUT_SECONDS = DefaultSessionTimeoutSeconds;
+#pragma warning restore SA1310, IDE1006
+
+        private static readonly TlsSessionCacheConfig DefaultInstance =
+            new TlsSessionCacheConfig(true, DefaultSessionCacheSize, DefaultSessionTimeoutSeconds);
+
+        private static readonly TlsSessionCacheConfig DisabledInstance =
+            new TlsSessionCacheConfig(false, 0, 0);
+
+        private TlsSessionCacheConfig(bool enabled, int sessionCacheSize, int sessionTimeoutSeconds)
+        {
+            this.Enabled = enabled;
+            this.SessionCacheSize = sessionCacheSize;
+            this.SessionTimeoutSeconds = sessionTimeoutSeconds;
+        }
+
+        public bool Enabled { get; }
+
+        public int SessionCacheSize { get; }
+
+        public int SessionTimeoutSeconds { get; }
+
+        public static TlsSessionCacheConfig GetDefault()
+        {
+            return DefaultInstance;
+        }
+
+        public static TlsSessionCacheConfig Disabled()
+        {
+            return DisabledInstance;
+        }
+
+        public static TlsSessionCacheConfigBuilder Builder()
+        {
+            return new TlsSessionCacheConfigBuilder();
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public static TlsSessionCacheConfig getDefault()
+        {
+            return GetDefault();
+        }
+
+        public static TlsSessionCacheConfig disabled()
+        {
+            return Disabled();
+        }
+
+        public static TlsSessionCacheConfigBuilder builder()
+        {
+            return Builder();
+        }
+
+        public bool isEnabled()
+        {
+            return this.Enabled;
+        }
+
+        public int getSessionCacheSize()
+        {
+            return this.SessionCacheSize;
+        }
+
+        public int getSessionTimeoutSeconds()
+        {
+            return this.SessionTimeoutSeconds;
+        }
+#pragma warning restore SA1300, IDE1006
+
+        public override string ToString()
+        {
+            return "TlsSessionCacheConfig{"
+                + "enabled="
+                + this.Enabled.ToString().ToLowerInvariant()
+                + ", sessionCacheSize="
+                + this.SessionCacheSize
+                + ", sessionTimeoutSeconds="
+                + this.SessionTimeoutSeconds
+                + "}";
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is TlsSessionCacheConfig other
+                && this.Enabled == other.Enabled
+                && this.SessionCacheSize == other.SessionCacheSize
+                && this.SessionTimeoutSeconds == other.SessionTimeoutSeconds;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(this.Enabled, this.SessionCacheSize, this.SessionTimeoutSeconds);
+        }
+
+        internal static TlsSessionCacheConfig Create(bool enabled, int sessionCacheSize, int sessionTimeoutSeconds)
+        {
+            return new TlsSessionCacheConfig(enabled, sessionCacheSize, sessionTimeoutSeconds);
+        }
+    }
+}

--- a/TlsSessionCacheConfigBuilder.cs
+++ b/TlsSessionCacheConfigBuilder.cs
@@ -1,0 +1,75 @@
+// <copyright file="TlsSessionCacheConfigBuilder.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    public sealed class TlsSessionCacheConfigBuilder
+    {
+        private bool enabled = true;
+        private int sessionCacheSize = TlsSessionCacheConfig.DefaultSessionCacheSize;
+        private int sessionTimeoutSeconds = TlsSessionCacheConfig.DefaultSessionTimeoutSeconds;
+
+        public TlsSessionCacheConfigBuilder WithEnabled(bool enabled)
+        {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public TlsSessionCacheConfigBuilder WithSessionCacheSize(int sessionCacheSize)
+        {
+            this.sessionCacheSize = sessionCacheSize;
+            return this;
+        }
+
+        public TlsSessionCacheConfigBuilder WithSessionTimeoutSeconds(int sessionTimeoutSeconds)
+        {
+            this.sessionTimeoutSeconds = sessionTimeoutSeconds;
+            return this;
+        }
+
+        public TlsSessionCacheConfig Build()
+        {
+            if (this.enabled)
+            {
+                if (this.sessionCacheSize <= 0)
+                {
+                    throw new ArgumentException(
+                        "sessionCacheSize must be positive when TLS session cache is enabled, but was: " + this.sessionCacheSize,
+                        nameof(this.sessionCacheSize));
+                }
+
+                if (this.sessionTimeoutSeconds <= 0)
+                {
+                    throw new ArgumentException(
+                        "sessionTimeoutSeconds must be positive when TLS session cache is enabled, but was: " + this.sessionTimeoutSeconds,
+                        nameof(this.sessionTimeoutSeconds));
+                }
+            }
+
+            return TlsSessionCacheConfig.Create(this.enabled, this.sessionCacheSize, this.sessionTimeoutSeconds);
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public TlsSessionCacheConfigBuilder withEnabled(bool enabled)
+        {
+            return this.WithEnabled(enabled);
+        }
+
+        public TlsSessionCacheConfigBuilder withSessionCacheSize(int sessionCacheSize)
+        {
+            return this.WithSessionCacheSize(sessionCacheSize);
+        }
+
+        public TlsSessionCacheConfigBuilder withSessionTimeoutSeconds(int sessionTimeoutSeconds)
+        {
+            return this.WithSessionTimeoutSeconds(sessionTimeoutSeconds);
+        }
+
+        public TlsSessionCacheConfig build()
+        {
+            return this.Build();
+        }
+#pragma warning restore SA1300, IDE1006
+    }
+}

--- a/UnitTests/ConfigValueObjectUnitTests.cs
+++ b/UnitTests/ConfigValueObjectUnitTests.cs
@@ -1,0 +1,157 @@
+// <copyright file="ConfigValueObjectUnitTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    using ScyllaDB.Alternator.KeyRouting;
+    using ScyllaDB.Alternator.Routing;
+
+    [TestFixture]
+    [Category("Unit")]
+    public class ConfigValueObjectUnitTests
+    {
+        [Test]
+        public void RequestCompressionAlgorithmSupportsJavaStyleEnabledCheckTest()
+        {
+            Assert.That(RequestCompressionAlgorithm.NONE.isEnabled(), Is.False);
+            Assert.That(RequestCompressionAlgorithm.GZIP.isEnabled(), Is.True);
+        }
+
+        [Test]
+        public void HttpClientTypeSupportsJavaStyleCapabilityChecksTest()
+        {
+            Assert.That(HttpClientType.AUTO.supportsSync(), Is.True);
+            Assert.That(HttpClientType.AUTO.supportsAsync(), Is.True);
+            Assert.That(HttpClientType.APACHE.supportsSync(), Is.True);
+            Assert.That(HttpClientType.APACHE.supportsAsync(), Is.False);
+            Assert.That(HttpClientType.NETTY.supportsSync(), Is.False);
+            Assert.That(HttpClientType.NETTY.supportsAsync(), Is.True);
+            Assert.That(HttpClientType.CRT.supportsSync(), Is.True);
+            Assert.That(HttpClientType.CRT.supportsAsync(), Is.True);
+        }
+
+        [Test]
+        public void RoutingScopesSupportJavaStyleAccessorsAndValueEqualityTest()
+        {
+            var cluster = ClusterScope.create();
+            Assert.That(cluster.getName(), Is.EqualTo("Cluster"));
+            Assert.That(cluster.getDescription(), Is.EqualTo("Cluster (all nodes)"));
+            Assert.That(cluster.getFallback(), Is.Null);
+            Assert.That(cluster.getLocalNodesQuery(), Is.EqualTo(string.Empty));
+            Assert.That(ClusterScope.create(), Is.SameAs(cluster));
+
+            var datacenter = DatacenterScope.of("dc1", cluster);
+            Assert.That(datacenter.getDatacenter(), Is.EqualTo("dc1"));
+            Assert.That(datacenter.getName(), Is.EqualTo("Datacenter"));
+            Assert.That(datacenter.getDescription(), Is.EqualTo("Datacenter dc1"));
+            Assert.That(datacenter.getFallback(), Is.SameAs(cluster));
+            Assert.That(datacenter.getLocalNodesQuery(), Is.EqualTo("dc=dc1"));
+            Assert.That(DatacenterScope.of("dc1", ClusterScope.create()), Is.EqualTo(datacenter));
+            Assert.That(DatacenterScope.of("dc2", ClusterScope.create()), Is.Not.EqualTo(datacenter));
+
+            var rack = RackScope.of("dc1", "rack1", datacenter);
+            Assert.That(rack.getRack(), Is.EqualTo("rack1"));
+            Assert.That(rack.getName(), Is.EqualTo("Rack"));
+            Assert.That(rack.getDescription(), Is.EqualTo("Rack rack1 in Datacenter dc1"));
+            Assert.That(rack.getFallback(), Is.SameAs(datacenter));
+            Assert.That(rack.getLocalNodesQuery(), Is.EqualTo("dc=dc1&rack=rack1"));
+            Assert.That(RackScope.of("dc1", "rack1", DatacenterScope.of("dc1", ClusterScope.create())), Is.EqualTo(rack));
+            Assert.That(RackScope.of("dc1", "rack2", datacenter), Is.Not.EqualTo(rack));
+
+            Assert.Throws<ArgumentException>(() => DatacenterScope.of(string.Empty, null));
+            Assert.Throws<ArgumentException>(() => RackScope.of("dc1", string.Empty, null));
+        }
+
+        [Test]
+        public void TlsConfigAndSessionCacheSupportJavaStyleBuildersTest()
+        {
+            var sessionCache = TlsSessionCacheConfig.builder()
+                .withEnabled(true)
+                .withSessionCacheSize(50)
+                .withSessionTimeoutSeconds(1800)
+                .build();
+            var sameSessionCache = TlsSessionCacheConfig.builder()
+                .withEnabled(true)
+                .withSessionCacheSize(50)
+                .withSessionTimeoutSeconds(1800)
+                .build();
+
+            Assert.That(sessionCache.isEnabled(), Is.True);
+            Assert.That(sessionCache.getSessionCacheSize(), Is.EqualTo(50));
+            Assert.That(sessionCache.getSessionTimeoutSeconds(), Is.EqualTo(1800));
+            Assert.That(sessionCache, Is.EqualTo(sameSessionCache));
+            Assert.That(TlsSessionCacheConfig.getDefault().isEnabled(), Is.True);
+            Assert.That(TlsSessionCacheConfig.disabled().isEnabled(), Is.False);
+
+            var tls = TlsConfig.builder()
+                .withCaCertPath("/tmp/ca.pem")
+                .withClientCertificate("/tmp/client.crt", "/tmp/client.key")
+                .withTrustSystemCaCerts(false)
+                .withSessionCacheConfig(sessionCache)
+                .build();
+
+            Assert.That(tls.getCustomCaCertPaths(), Is.EqualTo(new[] { "/tmp/ca.pem" }));
+            Assert.That(tls.hasClientCertificate(), Is.True);
+            Assert.That(tls.isTrustSystemCaCerts(), Is.False);
+            Assert.That(tls.isTrustAllCertificates(), Is.False);
+            Assert.That(tls.isVerifyHostname(), Is.True);
+            Assert.That(tls.getSessionCacheConfig(), Is.SameAs(sessionCache));
+            Assert.That(TlsConfig.trustAll().isTrustAllCertificates(), Is.True);
+            Assert.That(TlsConfig.systemDefault().isTrustSystemCaCerts(), Is.True);
+        }
+
+        [Test]
+        public void KeyRouteAffinityConfigSupportsJavaStyleBuilderAndReadOnlyMapTest()
+        {
+            var config = KeyRouteAffinityConfig.builder()
+                .withType(KeyRouteAffinity.RMW)
+                .withPkInfo("orders", "order_id")
+                .withPkInfoMap(new Dictionary<string, string> { ["users"] = "user_id" })
+                .build();
+
+            Assert.That(config.isEnabled(), Is.True);
+            Assert.That(config.getType(), Is.EqualTo(KeyRouteAffinity.Rmw));
+            Assert.That(config.getPkInfoPerTable()["orders"], Is.EqualTo("order_id"));
+            Assert.That(config.getPkInfoPerTable()["users"], Is.EqualTo("user_id"));
+            Assert.Throws<NotSupportedException>(() =>
+                ((IDictionary<string, string>)config.getPkInfoPerTable()).Add("products", "product_id"));
+            Assert.That(KeyRouteAffinityConfig.of(null).isEnabled(), Is.False);
+        }
+
+        [Test]
+        public void AlternatorConfigBuilderComputesRequiredHeadersAndValidatesScalarsTest()
+        {
+            var config = AlternatorConfig.builder()
+                .withSeedNode("https://127.0.0.1:8043")
+                .withRoutingScope(DatacenterScope.of("dc1", ClusterScope.create()))
+                .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+                .withOptimizeHeaders(true)
+                .withUserAgentEnabled(false)
+                .withAuthenticationEnabled(false)
+                .withMaxConnections(50)
+                .build();
+
+            Assert.That(config.getSeedHosts(), Is.EqualTo(new[] { "127.0.0.1" }));
+            Assert.That(config.getScheme(), Is.EqualTo("https"));
+            Assert.That(config.getPort(), Is.EqualTo(8043));
+            Assert.That(config.getRoutingScope().getLocalNodesQuery(), Is.EqualTo("dc=dc1"));
+            Assert.That(config.getRequiredHeaders(), Does.Contain("Content-Encoding"));
+            Assert.That(config.getRequiredHeaders(), Does.Not.Contain("User-Agent"));
+            Assert.That(config.getRequiredHeaders(), Does.Not.Contain("Authorization"));
+            Assert.That(config.getMaxConnections(), Is.EqualTo(50));
+            Assert.Throws<NotSupportedException>(() =>
+                ((ISet<string>)config.getRequiredHeaders()).Add("X-Test"));
+
+            Assert.Throws<ArgumentException>(() => AlternatorConfig.builder()
+                .withMinCompressionSizeBytes(-1)
+                .build());
+            Assert.Throws<ArgumentException>(() => AlternatorConfig.builder()
+                .withMaxConnections(0)
+                .build());
+            Assert.Throws<ArgumentException>(() => AlternatorConfig.builder()
+                .withHeadersWhitelist(new[] { "Host" })
+                .build());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Java-style Alternator config, routing scope, TLS, compression, HTTP client type, and key-affinity config value objects
- add immutable read-only set support for header collections
- cover Java-style builders/accessors, header requirement computation, validation, and value equality

## Local verification
- dotnet restore ScyllaDB.Alternator.sln --verbosity minimal
- make build
- make check
- make test-unit
