### PR TITLE
Add key affinity routing

### DIFF
--- a/AffinityQueryPlanInterceptor.cs
+++ b/AffinityQueryPlanInterceptor.cs
@@ -1,0 +1,160 @@
+// <copyright file="AffinityQueryPlanInterceptor.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    using Amazon.DynamoDBv2;
+    using Amazon.Runtime;
+    using ScyllaDB.Alternator.KeyRouting;
+
+    public class AffinityQueryPlanInterceptor : BasicQueryPlanInterceptor
+    {
+        private readonly KeyRouteAffinityConfig? config;
+        private readonly PartitionKeyResolver? partitionKeyResolver;
+
+        public AffinityQueryPlanInterceptor(
+            KeyRouteAffinityConfig config,
+            AlternatorLiveNodes liveNodes,
+            IAmazonDynamoDB? clientForDiscovery)
+            : this(
+                config,
+                liveNodes,
+                new PartitionKeyResolver(config?.PkInfoPerTable.ToDictionary(item => item.Key, item => item.Value)))
+        {
+            if (clientForDiscovery != null)
+            {
+                this.SetClientForDiscovery(clientForDiscovery);
+            }
+        }
+
+        public AffinityQueryPlanInterceptor(
+            KeyRouteAffinityConfig config,
+            AlternatorLiveNodes liveNodes)
+            : this(config, liveNodes, (IAmazonDynamoDB?)null)
+        {
+        }
+
+        internal AffinityQueryPlanInterceptor(
+            KeyRouteAffinityConfig? config,
+            AlternatorLiveNodes liveNodes,
+            PartitionKeyResolver? partitionKeyResolver)
+            : base(liveNodes)
+        {
+            this.config = config;
+            this.partitionKeyResolver = partitionKeyResolver;
+        }
+
+        public KeyRouteAffinityConfig? Config => this.config;
+
+        public PartitionKeyResolver? PartitionKeyResolver => this.partitionKeyResolver;
+
+        public PartitionKeyResolver? GetPartitionKeyResolver()
+        {
+            return this.partitionKeyResolver;
+        }
+
+        public KeyRouteAffinityConfig? GetConfig()
+        {
+            return this.config;
+        }
+
+        public void SetClientForDiscovery(IAmazonDynamoDB client)
+        {
+            this.partitionKeyResolver?.SetClientForDiscovery(client);
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public PartitionKeyResolver? getPartitionKeyResolver()
+        {
+            return this.GetPartitionKeyResolver();
+        }
+
+        public KeyRouteAffinityConfig? getConfig()
+        {
+            return this.GetConfig();
+        }
+
+        public void setClientForDiscovery(IAmazonDynamoDB client)
+        {
+            this.SetClientForDiscovery(client);
+        }
+#pragma warning restore SA1300, IDE1006
+
+        protected override LazyQueryPlan CreateQueryPlan(AmazonWebServiceRequest originalRequest)
+        {
+            return this.TryCreateAffinityQueryPlan(originalRequest) ?? base.CreateQueryPlan(originalRequest);
+        }
+
+        private LazyQueryPlan? TryCreateAffinityQueryPlan(AmazonWebServiceRequest originalRequest)
+        {
+            if (this.config?.IsEnabled != true
+                || this.partitionKeyResolver == null
+                || !KeyAffinityRequestClassifier.ShouldApply(this.config.Type, originalRequest))
+            {
+                return null;
+            }
+
+            if (originalRequest is Amazon.DynamoDBv2.Model.BatchWriteItemRequest batchWriteItem)
+            {
+                return this.TryCreateBatchWriteAffinityQueryPlan(batchWriteItem);
+            }
+
+            var tableName = KeyAffinityRequestClassifier.ExtractTableName(originalRequest);
+            if (string.IsNullOrEmpty(tableName))
+            {
+                return null;
+            }
+
+            var partitionKeyName = this.partitionKeyResolver.GetPartitionKeyName(tableName);
+            if (partitionKeyName == null)
+            {
+                this.partitionKeyResolver.TriggerDiscovery(tableName);
+                return null;
+            }
+
+            var partitionKey = KeyAffinityRequestClassifier.ExtractPartitionKey(originalRequest, partitionKeyName);
+            if (partitionKey == null)
+            {
+                return null;
+            }
+
+            return this.LiveNodes.CreateQueryPlan(AttributeValueHasher.Hash(partitionKey));
+        }
+
+        private LazyQueryPlan? TryCreateBatchWriteAffinityQueryPlan(Amazon.DynamoDBv2.Model.BatchWriteItemRequest request)
+        {
+            var resolver = this.partitionKeyResolver;
+            if (resolver == null)
+            {
+                return null;
+            }
+
+            foreach (var target in KeyAffinityRequestClassifier.ExtractBatchWriteRoutingTargets(request))
+            {
+                var partitionKeyName = resolver.GetPartitionKeyName(target.TableName);
+                if (partitionKeyName == null)
+                {
+                    resolver.TriggerDiscovery(target.TableName);
+                    return null;
+                }
+
+                var partitionKey = target.PartitionKeyValue(partitionKeyName);
+                if (partitionKey == null)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    return this.LiveNodes.CreateQueryPlan(AttributeValueHasher.Hash(partitionKey));
+                }
+                catch (ArgumentException)
+                {
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/BasicQueryPlanInterceptor.cs
+++ b/BasicQueryPlanInterceptor.cs
@@ -1,0 +1,82 @@
+// <copyright file="BasicQueryPlanInterceptor.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    using Amazon.Runtime;
+    using Amazon.Runtime.Internal;
+    using ScyllaDB.Alternator.KeyRouting;
+
+    public class BasicQueryPlanInterceptor : PipelineHandler
+    {
+        protected const string QueryPlanContextKey = "ScyllaDB.Alternator.QueryPlan";
+
+        private readonly AlternatorLiveNodes liveNodes;
+
+        public BasicQueryPlanInterceptor(AlternatorLiveNodes liveNodes)
+        {
+            this.liveNodes = liveNodes ?? throw new ArgumentNullException(nameof(liveNodes));
+        }
+
+        public AlternatorLiveNodes LiveNodes => this.liveNodes;
+
+        public override void InvokeSync(IExecutionContext executionContext)
+        {
+            this.ApplyEndpoint(executionContext.RequestContext);
+            base.InvokeSync(executionContext);
+        }
+
+        public override Task<T> InvokeAsync<T>(IExecutionContext executionContext)
+        {
+            this.ApplyEndpoint(executionContext.RequestContext);
+            return base.InvokeAsync<T>(executionContext);
+        }
+
+        public LazyQueryPlan GetOrCreateQueryPlan(
+            AmazonWebServiceRequest originalRequest,
+            IDictionary<string, object> contextAttributes)
+        {
+            if (contextAttributes.TryGetValue(QueryPlanContextKey, out var storedQueryPlan)
+                && storedQueryPlan is LazyQueryPlan queryPlan)
+            {
+                return queryPlan;
+            }
+
+            queryPlan = this.CreateQueryPlan(originalRequest);
+            contextAttributes[QueryPlanContextKey] = queryPlan;
+            return queryPlan;
+        }
+
+        public AlternatorLiveNodes GetLiveNodes()
+        {
+            return this.liveNodes;
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public AlternatorLiveNodes getLiveNodes()
+        {
+            return this.GetLiveNodes();
+        }
+#pragma warning restore SA1300, IDE1006
+
+        protected virtual LazyQueryPlan CreateQueryPlan(AmazonWebServiceRequest originalRequest)
+        {
+            return this.liveNodes.CreateQueryPlan();
+        }
+
+        private void ApplyEndpoint(IRequestContext requestContext)
+        {
+            var queryPlan = this.GetOrCreateQueryPlan(requestContext.OriginalRequest, requestContext.ContextAttributes);
+            if (!queryPlan.HasNext)
+            {
+                return;
+            }
+
+            var target = queryPlan.Next();
+            requestContext.Request.Endpoint = target;
+            requestContext.Request.Headers["Host"] = target.IsDefaultPort ? target.Host : $"{target.Host}:{target.Port}";
+            requestContext.Request.Headers["Connection"] = "keep-alive";
+        }
+    }
+}

--- a/KeyRouting/AttributeValueHasher.cs
+++ b/KeyRouting/AttributeValueHasher.cs
@@ -1,0 +1,63 @@
+// <copyright file="AttributeValueHasher.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator.KeyRouting
+{
+    using System.Text;
+    using Amazon.DynamoDBv2.Model;
+
+    public static class AttributeValueHasher
+    {
+        private const byte TypeString = 0x01;
+        private const byte TypeNumber = 0x02;
+        private const byte TypeBinary = 0x03;
+
+        public static long Hash(AttributeValue? value)
+        {
+            if (value == null)
+            {
+                return 0;
+            }
+
+            return MurmurHash3.Hash(ToBytes(value));
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public static long hash(AttributeValue? value)
+        {
+            return Hash(value);
+        }
+#pragma warning restore SA1300, IDE1006
+
+        private static byte[] PrependTypePrefix(byte typePrefix, byte[] value)
+        {
+            var bytes = new byte[value.Length + 1];
+            bytes[0] = typePrefix;
+            Buffer.BlockCopy(value, 0, bytes, 1, value.Length);
+            return bytes;
+        }
+
+        private static byte[] ToBytes(AttributeValue value)
+        {
+            if (value.S != null)
+            {
+                return PrependTypePrefix(TypeString, Encoding.UTF8.GetBytes(value.S));
+            }
+
+            if (value.N != null)
+            {
+                return PrependTypePrefix(TypeNumber, Encoding.UTF8.GetBytes(value.N));
+            }
+
+            if (value.B != null)
+            {
+                return PrependTypePrefix(TypeBinary, value.B.ToArray());
+            }
+
+            throw new ArgumentException(
+                "Unsupported AttributeValue type. Only S (String), N (Number), and B (Binary) are supported as partition key types in Alternator.",
+                nameof(value));
+        }
+    }
+}

--- a/KeyRouting/KeyAffinityRequestClassifier.cs
+++ b/KeyRouting/KeyAffinityRequestClassifier.cs
@@ -1,0 +1,494 @@
+// <copyright file="KeyAffinityRequestClassifier.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator.KeyRouting
+{
+    using System.Text;
+    using Amazon.DynamoDBv2;
+    using Amazon.DynamoDBv2.Model;
+    using Amazon.Runtime;
+
+    public static class KeyAffinityRequestClassifier
+    {
+        public static AttributeValue? ExtractPartitionKey(AmazonWebServiceRequest request, string? pkAttributeName)
+        {
+            if (pkAttributeName == null)
+            {
+                return null;
+            }
+
+            IDictionary<string, AttributeValue>? key = null;
+            if (request is UpdateItemRequest updateItem)
+            {
+                key = updateItem.Key;
+            }
+            else if (request is PutItemRequest putItem)
+            {
+                key = putItem.Item;
+            }
+            else if (request is DeleteItemRequest deleteItem)
+            {
+                key = deleteItem.Key;
+            }
+            else if (request is GetItemRequest getItem)
+            {
+                key = getItem.Key;
+            }
+            else if (request is BatchWriteItemRequest batchWriteItem)
+            {
+                foreach (var target in ExtractBatchWriteRoutingTargets(batchWriteItem))
+                {
+                    var partitionKey = target.PartitionKeyValue(pkAttributeName);
+                    if (partitionKey != null)
+                    {
+                        return partitionKey;
+                    }
+                }
+            }
+
+            if (key != null && key.TryGetValue(pkAttributeName, out var value))
+            {
+                return value;
+            }
+
+            return null;
+        }
+
+        public static string? ExtractTableName(AmazonWebServiceRequest request)
+        {
+            return request switch
+            {
+                UpdateItemRequest updateItem => updateItem.TableName,
+                PutItemRequest putItem => putItem.TableName,
+                DeleteItemRequest deleteItem => deleteItem.TableName,
+                GetItemRequest getItem => getItem.TableName,
+                QueryRequest query => query.TableName,
+                BatchWriteItemRequest batchWriteItem => FindBatchWriteRoutingTarget(batchWriteItem)?.TableName,
+                _ => null,
+            };
+        }
+
+        public static bool ShouldApply(KeyRouteAffinity mode, AmazonWebServiceRequest request)
+        {
+            if (mode == KeyRouteAffinity.None)
+            {
+                return false;
+            }
+
+            return request switch
+            {
+                UpdateItemRequest updateItem => ShouldApplyUpdateItem(mode, updateItem),
+                PutItemRequest putItem => ShouldApplyPutItem(mode, putItem),
+                DeleteItemRequest deleteItem => ShouldApplyDeleteItem(mode, deleteItem),
+                BatchWriteItemRequest batchWriteItem => ShouldApplyBatchWriteItem(mode, batchWriteItem),
+                _ => false,
+            };
+        }
+
+        public static IReadOnlyList<BatchWriteRoutingTarget> ExtractBatchWriteRoutingTargets(BatchWriteItemRequest request)
+        {
+            if (request.RequestItems == null || request.RequestItems.Count == 0)
+            {
+                return Array.Empty<BatchWriteRoutingTarget>();
+            }
+
+            var candidates = new List<BatchWriteRoutingTarget>();
+            foreach (var table in request.RequestItems)
+            {
+                if (table.Value == null)
+                {
+                    continue;
+                }
+
+                foreach (var write in table.Value)
+                {
+                    if (write.PutRequest != null)
+                    {
+                        candidates.Add(new BatchWriteRoutingTarget(
+                            table.Key,
+                            write.PutRequest.Item,
+                            "PutRequest",
+                            CanonicalAttributeValues(write.PutRequest.Item)));
+                    }
+
+                    if (write.DeleteRequest != null)
+                    {
+                        candidates.Add(new BatchWriteRoutingTarget(
+                            table.Key,
+                            write.DeleteRequest.Key,
+                            "DeleteRequest",
+                            CanonicalAttributeValues(write.DeleteRequest.Key)));
+                    }
+                }
+            }
+
+            return candidates
+                .OrderBy(target => target.TableName, StringComparer.Ordinal)
+                .ThenBy(target => target.CanonicalAttributes, StringComparer.Ordinal)
+                .ThenBy(target => target.Operation, StringComparer.Ordinal)
+                .ToList()
+                .AsReadOnly();
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public static AttributeValue? extractPartitionKey(AmazonWebServiceRequest request, string? pkAttributeName)
+        {
+            return ExtractPartitionKey(request, pkAttributeName);
+        }
+
+        public static string? extractTableName(AmazonWebServiceRequest request)
+        {
+            return ExtractTableName(request);
+        }
+
+        public static bool shouldApply(KeyRouteAffinity mode, AmazonWebServiceRequest request)
+        {
+            return ShouldApply(mode, request);
+        }
+
+        public static IReadOnlyList<BatchWriteRoutingTarget> extractBatchWriteRoutingTargets(BatchWriteItemRequest request)
+        {
+            return ExtractBatchWriteRoutingTargets(request);
+        }
+#pragma warning restore SA1300, IDE1006
+
+        private static string CanonicalAttributeValues(IDictionary<string, AttributeValue>? values)
+        {
+            if (values == null || values.Count == 0)
+            {
+                return "{}";
+            }
+
+            var builder = new StringBuilder();
+            builder.Append('{');
+            var first = true;
+            foreach (var key in values.Keys.OrderBy(key => key, StringComparer.Ordinal))
+            {
+                if (!first)
+                {
+                    builder.Append(',');
+                }
+
+                first = false;
+                AppendQuoted(builder, key);
+                builder.Append(':');
+                AppendCanonicalAttributeValue(builder, values[key]);
+            }
+
+            builder.Append('}');
+            return builder.ToString();
+        }
+
+        private static void AppendCanonicalAttributeValue(StringBuilder builder, AttributeValue? value)
+        {
+            if (value == null)
+            {
+                builder.Append("{\"UNKNOWN\":true}");
+                return;
+            }
+
+            if (value.S != null)
+            {
+                AppendTaggedJsonString(builder, "S", value.S);
+                return;
+            }
+
+            if (value.N != null)
+            {
+                AppendTaggedJsonString(builder, "N", value.N);
+                return;
+            }
+
+            if (value.B != null)
+            {
+                builder.Append("{\"B\":{\"__bytes__\":\"");
+                AppendHex(builder, value.B.ToArray());
+                builder.Append("\"}}");
+                return;
+            }
+
+            if (value.IsBOOLSet)
+            {
+                builder.Append("{\"BOOL\":").Append(value.BOOL == true ? "true" : "false").Append('}');
+                return;
+            }
+
+            if (value.NULL == true)
+            {
+                builder.Append("{\"NULL\":true}");
+                return;
+            }
+
+            if (value.IsSSSet)
+            {
+                AppendTaggedJsonStringList(builder, "SS", value.SS);
+                return;
+            }
+
+            if (value.IsNSSet)
+            {
+                AppendTaggedJsonStringList(builder, "NS", value.NS);
+                return;
+            }
+
+            if (value.IsBSSet)
+            {
+                builder.Append("{\"BS\":[");
+                for (var index = 0; index < value.BS.Count; index++)
+                {
+                    if (index > 0)
+                    {
+                        builder.Append(',');
+                    }
+
+                    builder.Append("{\"__bytes__\":\"");
+                    AppendHex(builder, value.BS[index].ToArray());
+                    builder.Append("\"}");
+                }
+
+                builder.Append("]}");
+                return;
+            }
+
+            if (value.IsLSet)
+            {
+                builder.Append("{\"L\":[");
+                for (var index = 0; index < value.L.Count; index++)
+                {
+                    if (index > 0)
+                    {
+                        builder.Append(',');
+                    }
+
+                    AppendCanonicalAttributeValue(builder, value.L[index]);
+                }
+
+                builder.Append("]}");
+                return;
+            }
+
+            if (value.IsMSet)
+            {
+                builder.Append("{\"M\":");
+                builder.Append(CanonicalAttributeValues(value.M));
+                builder.Append('}');
+                return;
+            }
+
+            builder.Append("{\"UNKNOWN\":true}");
+        }
+
+        private static void AppendHex(StringBuilder builder, byte[] bytes)
+        {
+            const string Hex = "0123456789abcdef";
+            foreach (var value in bytes)
+            {
+                builder.Append(Hex[(value >> 4) & 0x0f]);
+                builder.Append(Hex[value & 0x0f]);
+            }
+        }
+
+        private static void AppendHex4(StringBuilder builder, char value)
+        {
+            const string Hex = "0123456789abcdef";
+            builder.Append(Hex[(value >> 12) & 0x0f]);
+            builder.Append(Hex[(value >> 8) & 0x0f]);
+            builder.Append(Hex[(value >> 4) & 0x0f]);
+            builder.Append(Hex[value & 0x0f]);
+        }
+
+        private static void AppendQuoted(StringBuilder builder, string value)
+        {
+            builder.Append('"');
+            foreach (var character in value)
+            {
+                switch (character)
+                {
+                    case '\\':
+                        builder.Append("\\\\");
+                        break;
+                    case '"':
+                        builder.Append("\\\"");
+                        break;
+                    case '\b':
+                        builder.Append("\\b");
+                        break;
+                    case '\f':
+                        builder.Append("\\f");
+                        break;
+                    case '\n':
+                        builder.Append("\\n");
+                        break;
+                    case '\r':
+                        builder.Append("\\r");
+                        break;
+                    case '\t':
+                        builder.Append("\\t");
+                        break;
+                    default:
+                        if (character <= 0x1f)
+                        {
+                            builder.Append("\\u");
+                            AppendHex4(builder, character);
+                        }
+                        else
+                        {
+                            builder.Append(character);
+                        }
+
+                        break;
+                }
+            }
+
+            builder.Append('"');
+        }
+
+        private static void AppendTaggedJsonString(StringBuilder builder, string tag, string value)
+        {
+            builder.Append("{\"");
+            builder.Append(tag);
+            builder.Append("\":");
+            AppendQuoted(builder, value);
+            builder.Append('}');
+        }
+
+        private static void AppendTaggedJsonStringList(StringBuilder builder, string tag, IList<string> values)
+        {
+            builder.Append("{\"");
+            builder.Append(tag);
+            builder.Append("\":[");
+            for (var index = 0; index < values.Count; index++)
+            {
+                if (index > 0)
+                {
+                    builder.Append(',');
+                }
+
+                AppendQuoted(builder, values[index]);
+            }
+
+            builder.Append("]}");
+        }
+
+        private static BatchWriteRoutingTarget? FindBatchWriteRoutingTarget(BatchWriteItemRequest request)
+        {
+            return ExtractBatchWriteRoutingTargets(request).FirstOrDefault();
+        }
+
+        private static bool HasExpected<TKey, TValue>(IDictionary<TKey, TValue>? values)
+        {
+            return values != null && values.Count != 0;
+        }
+
+        private static bool IsNotNone(ReturnValue? returnValue)
+        {
+            return returnValue != null && returnValue != ReturnValue.NONE;
+        }
+
+        private static bool ShouldApplyBatchWriteItem(KeyRouteAffinity mode, BatchWriteItemRequest request)
+        {
+            return mode == KeyRouteAffinity.AnyWrite
+                && ExtractBatchWriteRoutingTargets(request).Count != 0;
+        }
+
+        private static bool ShouldApplyDeleteItem(KeyRouteAffinity mode, DeleteItemRequest request)
+        {
+            return mode == KeyRouteAffinity.AnyWrite
+                || !string.IsNullOrEmpty(request.ConditionExpression)
+                || HasExpected(request.Expected)
+                || IsNotNone(request.ReturnValues);
+        }
+
+        private static bool ShouldApplyPutItem(KeyRouteAffinity mode, PutItemRequest request)
+        {
+            return mode == KeyRouteAffinity.AnyWrite
+                || !string.IsNullOrEmpty(request.ConditionExpression)
+                || HasExpected(request.Expected)
+                || IsNotNone(request.ReturnValues);
+        }
+
+        private static bool ShouldApplyUpdateItem(KeyRouteAffinity mode, UpdateItemRequest request)
+        {
+            if (mode == KeyRouteAffinity.AnyWrite
+                || !string.IsNullOrEmpty(request.UpdateExpression)
+                || !string.IsNullOrEmpty(request.ConditionExpression)
+                || HasExpected(request.Expected)
+                || request.ReturnValues == ReturnValue.ALL_OLD
+                || request.ReturnValues == ReturnValue.UPDATED_OLD
+                || request.ReturnValues == ReturnValue.ALL_NEW)
+            {
+                return true;
+            }
+
+            if (request.AttributeUpdates == null)
+            {
+                return false;
+            }
+
+            return request.AttributeUpdates.Values.Any(update =>
+                update.Action == AttributeAction.ADD
+                || (update.Action == AttributeAction.DELETE && update.Value != null));
+        }
+
+        public sealed class BatchWriteRoutingTarget
+        {
+            internal BatchWriteRoutingTarget(
+                string tableName,
+                IDictionary<string, AttributeValue>? values,
+                string operation,
+                string canonicalAttributes)
+            {
+                this.TableName = tableName;
+                this.Values = values;
+                this.Operation = operation;
+                this.CanonicalAttributes = canonicalAttributes;
+            }
+
+            public string TableName { get; }
+
+            public IDictionary<string, AttributeValue>? Values { get; }
+
+            public string Operation { get; }
+
+            public string CanonicalAttributes { get; }
+
+            public AttributeValue? PartitionKeyValue(string? pkAttributeName)
+            {
+                if (this.Values == null || pkAttributeName == null)
+                {
+                    return null;
+                }
+
+                return this.Values.TryGetValue(pkAttributeName, out var value) ? value : null;
+            }
+
+#pragma warning disable SA1300, IDE1006
+            public string tableName()
+            {
+                return this.TableName;
+            }
+
+            public IDictionary<string, AttributeValue>? values()
+            {
+                return this.Values;
+            }
+
+            public string operation()
+            {
+                return this.Operation;
+            }
+
+            public string canonicalAttributes()
+            {
+                return this.CanonicalAttributes;
+            }
+
+            public AttributeValue? partitionKeyValue(string? pkAttributeName)
+            {
+                return this.PartitionKeyValue(pkAttributeName);
+            }
+#pragma warning restore SA1300, IDE1006
+        }
+    }
+}

--- a/KeyRouting/MurmurHash3.cs
+++ b/KeyRouting/MurmurHash3.cs
@@ -1,0 +1,160 @@
+// <copyright file="MurmurHash3.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator.KeyRouting
+{
+    public static class MurmurHash3
+    {
+        private const ulong C1 = 0x87c37b91114253d5UL;
+        private const ulong C2 = 0x4cf5ad432745937fUL;
+        private const ulong Fmix1 = 0xff51afd7ed558ccdUL;
+        private const ulong Fmix2 = 0xc4ceb9fe1a85ec53UL;
+
+        public static long Hash(byte[] data)
+        {
+            return Hash(data, 0, data.Length);
+        }
+
+        public static long Hash(byte[] data, int offset, int length)
+        {
+            unchecked
+            {
+                ulong h1 = 0;
+                ulong h2 = 0;
+                var blocks = length / 16;
+                for (var i = 0; i < blocks; i++)
+                {
+                    var k1 = GetBlock(data, offset + (i * 16));
+                    var k2 = GetBlock(data, offset + (i * 16) + 8);
+
+                    k1 *= C1;
+                    k1 = RotateLeft(k1, 31);
+                    k1 *= C2;
+                    h1 ^= k1;
+
+                    h1 = RotateLeft(h1, 27);
+                    h1 += h2;
+                    h1 = (h1 * 5) + 0x52dce729UL;
+
+                    k2 *= C2;
+                    k2 = RotateLeft(k2, 33);
+                    k2 *= C1;
+                    h2 ^= k2;
+
+                    h2 = RotateLeft(h2, 31);
+                    h2 += h1;
+                    h2 = (h2 * 5) + 0x38495ab5UL;
+                }
+
+                var tailOffset = offset + (blocks * 16);
+                ulong tailK1 = 0;
+                ulong tailK2 = 0;
+                switch (length & 15)
+                {
+                    case 15:
+                        tailK2 ^= (ulong)data[tailOffset + 14] << 48;
+                        goto case 14;
+                    case 14:
+                        tailK2 ^= (ulong)data[tailOffset + 13] << 40;
+                        goto case 13;
+                    case 13:
+                        tailK2 ^= (ulong)data[tailOffset + 12] << 32;
+                        goto case 12;
+                    case 12:
+                        tailK2 ^= (ulong)data[tailOffset + 11] << 24;
+                        goto case 11;
+                    case 11:
+                        tailK2 ^= (ulong)data[tailOffset + 10] << 16;
+                        goto case 10;
+                    case 10:
+                        tailK2 ^= (ulong)data[tailOffset + 9] << 8;
+                        goto case 9;
+                    case 9:
+                        tailK2 ^= data[tailOffset + 8];
+                        tailK2 *= C2;
+                        tailK2 = RotateLeft(tailK2, 33);
+                        tailK2 *= C1;
+                        h2 ^= tailK2;
+                        goto case 8;
+                    case 8:
+                        tailK1 ^= (ulong)data[tailOffset + 7] << 56;
+                        goto case 7;
+                    case 7:
+                        tailK1 ^= (ulong)data[tailOffset + 6] << 48;
+                        goto case 6;
+                    case 6:
+                        tailK1 ^= (ulong)data[tailOffset + 5] << 40;
+                        goto case 5;
+                    case 5:
+                        tailK1 ^= (ulong)data[tailOffset + 4] << 32;
+                        goto case 4;
+                    case 4:
+                        tailK1 ^= (ulong)data[tailOffset + 3] << 24;
+                        goto case 3;
+                    case 3:
+                        tailK1 ^= (ulong)data[tailOffset + 2] << 16;
+                        goto case 2;
+                    case 2:
+                        tailK1 ^= (ulong)data[tailOffset + 1] << 8;
+                        goto case 1;
+                    case 1:
+                        tailK1 ^= data[tailOffset];
+                        tailK1 *= C1;
+                        tailK1 = RotateLeft(tailK1, 31);
+                        tailK1 *= C2;
+                        h1 ^= tailK1;
+                        break;
+                }
+
+                h1 ^= (ulong)length;
+                h2 ^= (ulong)length;
+                h1 += h2;
+                h2 += h1;
+                h1 = Fmix(h1);
+                h2 = Fmix(h2);
+                h1 += h2;
+                return (long)h1;
+            }
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public static long hash(byte[] data)
+        {
+            return Hash(data);
+        }
+
+        public static long hash(byte[] data, int offset, int length)
+        {
+            return Hash(data, offset, length);
+        }
+#pragma warning restore SA1300, IDE1006
+
+        private static ulong Fmix(ulong value)
+        {
+            value ^= value >> 33;
+            value *= Fmix1;
+            value ^= value >> 33;
+            value *= Fmix2;
+            value ^= value >> 33;
+            return value;
+        }
+
+        private static ulong GetBlock(byte[] data, int offset)
+        {
+            return data[offset]
+                | ((ulong)data[offset + 1] << 8)
+                | ((ulong)data[offset + 2] << 16)
+                | ((ulong)data[offset + 3] << 24)
+                | ((ulong)data[offset + 4] << 32)
+                | ((ulong)data[offset + 5] << 40)
+                | ((ulong)data[offset + 6] << 48)
+                | ((ulong)data[offset + 7] << 56);
+        }
+
+        private static ulong RotateLeft(ulong value, int count)
+        {
+            return (value << count) | (value >> (64 - count));
+        }
+    }
+}

--- a/KeyRouting/PartitionKeyResolver.cs
+++ b/KeyRouting/PartitionKeyResolver.cs
@@ -1,0 +1,328 @@
+// <copyright file="PartitionKeyResolver.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator.KeyRouting
+{
+    using System.Collections.Concurrent;
+    using System.Net;
+    using Amazon.DynamoDBv2;
+    using Amazon.DynamoDBv2.Model;
+
+    public sealed class PartitionKeyResolver : IDisposable
+    {
+        private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(5);
+
+        private readonly ConcurrentDictionary<string, string> cache = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, byte> discoveryInProgress = new ConcurrentDictionary<string, byte>(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<string, FailureRecord> failedTables = new ConcurrentDictionary<string, FailureRecord>(StringComparer.Ordinal);
+        private readonly ConcurrentBag<Task> discoveryTasks = new ConcurrentBag<Task>();
+        private readonly CancellationTokenSource shutdownSource = new CancellationTokenSource();
+        private readonly Func<string, CancellationToken, Task<DescribeTableResponse>>? describeTableAsync;
+        private IAmazonDynamoDB? clientForDiscovery;
+        private bool disposed;
+
+        public PartitionKeyResolver(IDictionary<string, string>? preConfigured)
+        {
+            if (preConfigured != null)
+            {
+                foreach (var item in preConfigured)
+                {
+                    this.cache[item.Key] = item.Value;
+                }
+            }
+        }
+
+        internal PartitionKeyResolver(
+            IDictionary<string, string>? preConfigured,
+            Func<string, CancellationToken, Task<DescribeTableResponse>> describeTableAsync)
+            : this(preConfigured)
+        {
+            this.describeTableAsync = describeTableAsync ?? throw new ArgumentNullException(nameof(describeTableAsync));
+        }
+
+        public string? GetPartitionKeyName(string tableName)
+        {
+            return this.cache.TryGetValue(tableName, out var partitionKeyName) ? partitionKeyName : null;
+        }
+
+        public void SetClientForDiscovery(IAmazonDynamoDB client)
+        {
+            this.clientForDiscovery = client ?? throw new ArgumentNullException(nameof(client));
+        }
+
+        public void TriggerDiscovery(string tableName)
+        {
+            var describe = this.describeTableAsync;
+            var client = this.clientForDiscovery;
+            if (describe == null)
+            {
+                if (client == null)
+                {
+                    return;
+                }
+
+                describe = (name, cancellationToken) => client.DescribeTableAsync(new DescribeTableRequest { TableName = name }, cancellationToken);
+            }
+
+            this.TriggerDiscovery(tableName, describe);
+        }
+
+        public void TriggerDiscovery(string tableName, IAmazonDynamoDB client)
+        {
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            this.TriggerDiscovery(tableName, (name, cancellationToken) => client.DescribeTableAsync(new DescribeTableRequest { TableName = name }, cancellationToken));
+        }
+
+        public void Register(string tableName, string pkAttributeName)
+        {
+            this.cache[tableName] = pkAttributeName;
+        }
+
+        public bool HasPartitionKeyInfo(string tableName)
+        {
+            return this.cache.ContainsKey(tableName);
+        }
+
+        public bool IsInFailureCooldown(string tableName)
+        {
+            return this.failedTables.TryGetValue(tableName, out var record) && !record.CanRetry();
+        }
+
+        public void ClearFailure(string tableName)
+        {
+            this.failedTables.TryRemove(tableName, out _);
+        }
+
+        public int GetFailedTableCount()
+        {
+            return this.failedTables.Count;
+        }
+
+        public void Shutdown()
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            this.disposed = true;
+            this.shutdownSource.Cancel();
+            try
+            {
+                Task.WaitAll(this.discoveryTasks.ToArray(), ShutdownTimeout);
+            }
+            catch (AggregateException)
+            {
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            finally
+            {
+                this.shutdownSource.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            this.Shutdown();
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public string? getPartitionKeyName(string tableName)
+        {
+            return this.GetPartitionKeyName(tableName);
+        }
+
+        public void setClientForDiscovery(IAmazonDynamoDB client)
+        {
+            this.SetClientForDiscovery(client);
+        }
+
+        public void triggerDiscovery(string tableName)
+        {
+            this.TriggerDiscovery(tableName);
+        }
+
+        public void triggerDiscovery(string tableName, IAmazonDynamoDB client)
+        {
+            this.TriggerDiscovery(tableName, client);
+        }
+
+        public void register(string tableName, string pkAttributeName)
+        {
+            this.Register(tableName, pkAttributeName);
+        }
+
+        public bool hasPartitionKeyInfo(string tableName)
+        {
+            return this.HasPartitionKeyInfo(tableName);
+        }
+
+        public bool isInFailureCooldown(string tableName)
+        {
+            return this.IsInFailureCooldown(tableName);
+        }
+
+        public void clearFailure(string tableName)
+        {
+            this.ClearFailure(tableName);
+        }
+
+        public int getFailedTableCount()
+        {
+            return this.GetFailedTableCount();
+        }
+
+        public void shutdownResolver()
+        {
+            this.Shutdown();
+        }
+
+        public void shutdown()
+        {
+            this.Shutdown();
+        }
+
+        public void close()
+        {
+            this.Dispose();
+        }
+#pragma warning restore SA1300, IDE1006
+
+        private static bool IsPermanentFailure(AmazonDynamoDBException exception)
+        {
+            if (exception.StatusCode == HttpStatusCode.Forbidden)
+            {
+                return true;
+            }
+
+            if (exception.ErrorCode == "AccessDeniedException" || exception.ErrorCode == "ValidationException")
+            {
+                return true;
+            }
+
+            return exception.StatusCode >= HttpStatusCode.BadRequest
+                && exception.StatusCode < HttpStatusCode.InternalServerError
+                && exception.StatusCode != (HttpStatusCode)429;
+        }
+
+        private static long CalculateJitteredDelay(long baseDelay)
+        {
+            var jitterRange = baseDelay * 0.2;
+            var jitter = ((Random.Shared.NextDouble() * 2) - 1) * jitterRange;
+            return Math.Max(1, (long)Math.Round(baseDelay + jitter));
+        }
+
+        private void TriggerDiscovery(
+            string tableName,
+            Func<string, CancellationToken, Task<DescribeTableResponse>> describe)
+        {
+            if (string.IsNullOrEmpty(tableName) || this.cache.ContainsKey(tableName) || this.disposed)
+            {
+                return;
+            }
+
+            if (this.failedTables.TryGetValue(tableName, out var failureRecord) && !failureRecord.CanRetry())
+            {
+                return;
+            }
+
+            if (!this.discoveryInProgress.TryAdd(tableName, 0))
+            {
+                return;
+            }
+
+            if (this.cache.ContainsKey(tableName))
+            {
+                this.discoveryInProgress.TryRemove(tableName, out _);
+                return;
+            }
+
+            this.failedTables.TryRemove(tableName, out _);
+            this.discoveryTasks.Add(Task.Run(() => this.DiscoverWithRetryAsync(tableName, describe, this.shutdownSource.Token)));
+        }
+
+        private async Task DiscoverWithRetryAsync(
+            string tableName,
+            Func<string, CancellationToken, Task<DescribeTableResponse>> describe,
+            CancellationToken cancellationToken)
+        {
+            var attempt = 0;
+            var delay = AlternatorConfig.RecommendedPartitionKeyDiscoveryInitialDelayMs;
+
+            try
+            {
+                while (attempt <= AlternatorConfig.RecommendedPartitionKeyDiscoveryMaxRetries)
+                {
+                    try
+                    {
+                        var response = await describe(tableName, cancellationToken).ConfigureAwait(false);
+                        var partitionKey = response.Table?.KeySchema?.FirstOrDefault(schema => schema.KeyType == KeyType.HASH);
+                        if (partitionKey?.AttributeName != null)
+                        {
+                            this.cache[tableName] = partitionKey.AttributeName;
+                            return;
+                        }
+
+                        this.failedTables[tableName] = new FailureRecord(permanent: true);
+                        return;
+                    }
+                    catch (ResourceNotFoundException)
+                    {
+                        this.failedTables[tableName] = new FailureRecord(permanent: true);
+                        return;
+                    }
+                    catch (AmazonDynamoDBException e) when (IsPermanentFailure(e))
+                    {
+                        this.failedTables[tableName] = new FailureRecord(permanent: true);
+                        return;
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+                    catch (Exception)
+                    {
+                        attempt++;
+                        if (attempt > AlternatorConfig.RecommendedPartitionKeyDiscoveryMaxRetries)
+                        {
+                            this.failedTables[tableName] = new FailureRecord(permanent: false);
+                            return;
+                        }
+
+                        var jitteredDelay = CalculateJitteredDelay(delay);
+                        await Task.Delay(TimeSpan.FromMilliseconds(jitteredDelay), cancellationToken).ConfigureAwait(false);
+                        delay = Math.Min(delay * 2, AlternatorConfig.RecommendedPartitionKeyDiscoveryMaxDelayMs);
+                    }
+                }
+            }
+            finally
+            {
+                this.discoveryInProgress.TryRemove(tableName, out _);
+            }
+        }
+
+        private sealed class FailureRecord
+        {
+            private readonly DateTimeOffset timestamp = DateTimeOffset.UtcNow;
+            private readonly bool permanent;
+
+            internal FailureRecord(bool permanent)
+            {
+                this.permanent = permanent;
+            }
+
+            internal bool CanRetry()
+            {
+                return !this.permanent
+                    || DateTimeOffset.UtcNow - this.timestamp > TimeSpan.FromMilliseconds(AlternatorConfig.RecommendedPartitionKeyDiscoveryCooldownMs);
+            }
+        }
+    }
+}

--- a/QueryPlanPipelineHandler.cs
+++ b/QueryPlanPipelineHandler.cs
@@ -1,0 +1,27 @@
+// <copyright file="QueryPlanPipelineHandler.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    using ScyllaDB.Alternator.KeyRouting;
+
+    public sealed class QueryPlanPipelineHandler : AffinityQueryPlanInterceptor
+    {
+        private readonly Helper endpointProvider;
+
+        public QueryPlanPipelineHandler(
+            Helper endpointProvider,
+            KeyRouteAffinityConfig? keyRouteAffinityConfig,
+            PartitionKeyResolver? partitionKeyResolver)
+            : base(
+                keyRouteAffinityConfig,
+                (endpointProvider ?? throw new ArgumentNullException(nameof(endpointProvider))).GetAlternatorLiveNodes(),
+                partitionKeyResolver)
+        {
+            this.endpointProvider = endpointProvider;
+        }
+
+        public Helper EndpointProvider => this.endpointProvider;
+    }
+}

--- a/UnitTests/KeyRoutingUnitTests.cs
+++ b/UnitTests/KeyRoutingUnitTests.cs
@@ -1,0 +1,1041 @@
+// <copyright file="KeyRoutingUnitTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    using Amazon.DynamoDBv2;
+    using Amazon.DynamoDBv2.Model;
+    using Amazon.Runtime;
+    using ScyllaDB.Alternator.KeyRouting;
+    using ScyllaDB.Alternator.Routing;
+
+    [TestFixture]
+    [Category("Unit")]
+    public class KeyRoutingUnitTests
+    {
+        [Test]
+        public void AttributeValueHasherMatchesCrossLanguageVectorsTest()
+        {
+            Assert.That(AttributeValueHasher.Hash(null), Is.EqualTo(0L));
+            Assert.That(AttributeValueHasher.hash(new AttributeValue { S = "hello" }), Is.EqualTo(8815023923555918238L));
+            Assert.That(AttributeValueHasher.hash(new AttributeValue { S = string.Empty }), Is.EqualTo(8849112093580131862L));
+            Assert.That(AttributeValueHasher.hash(new AttributeValue { S = "user_123" }), Is.EqualTo(-4025731529809423594L));
+            Assert.That(AttributeValueHasher.hash(new AttributeValue { N = "42" }), Is.EqualTo(-5061732451827723051L));
+            Assert.That(AttributeValueHasher.hash(new AttributeValue { N = "3.14159" }), Is.EqualTo(2139945193071104172L));
+            Assert.That(
+                AttributeValueHasher.hash(new AttributeValue { B = new MemoryStream(new byte[] { 0x01, 0x02, 0x03 }) }),
+                Is.EqualTo(5026299041734804437L));
+
+            var unsupported = Assert.Throws<ArgumentException>(() =>
+                AttributeValueHasher.hash(new AttributeValue { BOOL = true }));
+            Assert.That(
+                unsupported!.Message,
+                Does.Contain("Unsupported AttributeValue type. Only S (String), N (Number), and B (Binary) are supported as partition key types in Alternator."));
+        }
+
+        [Test]
+        public void MurmurHash3MatchesJavaAndGoVectorsTest()
+        {
+            Assert.That(MurmurHash3.Hash(Array.Empty<byte>()), Is.EqualTo(0L));
+            Assert.That(MurmurHash3.hash(System.Text.Encoding.UTF8.GetBytes("test")), Is.EqualTo(unchecked((long)0xac7d28cc74bde19dUL)));
+            Assert.That(MurmurHash3.hash(System.Text.Encoding.UTF8.GetBytes("hello")), Is.EqualTo(unchecked((long)0xcbd8a7b341bd9b02UL)));
+            Assert.That(MurmurHash3.hash(System.Text.Encoding.UTF8.GetBytes("user_123")), Is.EqualTo(0x104832bf621f0137L));
+            Assert.That(MurmurHash3.hash(System.Text.Encoding.UTF8.GetBytes("0123456789abcdef")), Is.EqualTo(0x4be06d94cf4ad1a7L));
+            Assert.That(MurmurHash3.hash(new byte[] { 0xff, 0x80, 0x7f, 0x00 }), Is.EqualTo(0x3408b0fbe4cb130cL));
+
+            var data = System.Text.Encoding.UTF8.GetBytes("prefixHELLOsuffix");
+            var hello = System.Text.Encoding.UTF8.GetBytes("HELLO");
+
+            Assert.That(MurmurHash3.hash(data, 6, 5), Is.EqualTo(MurmurHash3.Hash(hello)));
+        }
+
+        [Test]
+        public void BatchWriteItemKeyRouteAffinityMatchesCrossLanguageVectorsTest()
+        {
+            foreach (var vector in BatchWriteVectors())
+            {
+                var targets = KeyAffinityRequestClassifier.ExtractBatchWriteRoutingTargets(vector.Request);
+                Assert.That(targets, Is.Not.Empty, vector.Name);
+                Assert.That(KeyAffinityRequestClassifier.ShouldApply(KeyRouteAffinity.AnyWrite, vector.Request), Is.True, vector.Name);
+
+                var target = targets[0];
+                Assert.That(target.TableName, Is.EqualTo(vector.TableName), vector.Name);
+                Assert.That(target.Operation, Is.EqualTo(vector.Operation), vector.Name);
+                Assert.That(target.CanonicalAttributes, Is.EqualTo(vector.CanonicalAttributes), vector.Name);
+
+                var partitionKeyValue = target.PartitionKeyValue(vector.PkInfo[target.TableName]);
+                Assert.That(AttributeLabel(partitionKeyValue), Is.EqualTo(vector.PartitionKeyLabel), vector.Name);
+
+                var hash = BatchWriteHash(vector.Request, vector.PkInfo);
+                Assert.That(hash, Is.EqualTo(vector.HashSigned), vector.Name);
+                Assert.That(((ulong)hash).ToString(), Is.EqualTo(vector.HashUnsigned), vector.Name);
+                Assert.That(NodeSequence(hash, 6), Is.EqualTo(vector.FirstSixNodes), vector.Name);
+            }
+        }
+
+        [Test]
+        public void KeyAffinityRequestClassifierReturnsNullForNullPartitionKeyNameLikeJavaTest()
+        {
+            var putRequest = new PutItemRequest
+            {
+                TableName = "orders",
+                Item = Attributes("pk", StringAttribute("order-1")),
+            };
+            var batchRequest = BatchWrite(
+                Table("orders", Put(Attributes("pk", StringAttribute("order-1")))));
+
+            Assert.That(KeyAffinityRequestClassifier.extractPartitionKey(putRequest, null), Is.Null);
+            Assert.That(KeyAffinityRequestClassifier.extractPartitionKey(batchRequest, null), Is.Null);
+        }
+
+        [Test]
+        public void KeyAffinityRequestClassifierMatchesJavaRmwWriteRulesTest()
+        {
+            var key = Attributes("pk", StringAttribute("value"));
+            var item = Attributes("pk", StringAttribute("value"));
+
+            Assert.That(
+                KeyAffinityRequestClassifier.shouldApply(
+                    KeyRouteAffinity.NONE,
+                    new UpdateItemRequest
+                    {
+                        TableName = "test",
+                        Key = key,
+                        UpdateExpression = "SET x = :v",
+                    }),
+                Is.False);
+            Assert.That(
+                KeyAffinityRequestClassifier.shouldApply(
+                    KeyRouteAffinity.RMW,
+                    new UpdateItemRequest
+                    {
+                        TableName = "test",
+                        Key = key,
+                        UpdateExpression = "SET x = :v",
+                    }),
+                Is.True);
+            Assert.That(
+                KeyAffinityRequestClassifier.shouldApply(
+                    KeyRouteAffinity.RMW,
+                    new UpdateItemRequest
+                    {
+                        TableName = "test",
+                        Key = key,
+                        ReturnValues = ReturnValue.UPDATED_NEW,
+                    }),
+                Is.False);
+            Assert.That(
+                KeyAffinityRequestClassifier.shouldApply(
+                    KeyRouteAffinity.RMW,
+                    new UpdateItemRequest
+                    {
+                        TableName = "test",
+                        Key = key,
+                        ReturnValues = ReturnValue.ALL_NEW,
+                    }),
+                Is.True);
+            Assert.That(
+                KeyAffinityRequestClassifier.shouldApply(
+                    KeyRouteAffinity.RMW,
+                    new UpdateItemRequest
+                    {
+                        TableName = "test",
+                        Key = key,
+                        AttributeUpdates = new Dictionary<string, AttributeValueUpdate>
+                        {
+                            ["counter"] = new AttributeValueUpdate
+                            {
+                                Action = AttributeAction.ADD,
+                                Value = NumberAttribute("1"),
+                            },
+                        },
+                    }),
+                Is.True);
+            Assert.That(
+                KeyAffinityRequestClassifier.shouldApply(
+                    KeyRouteAffinity.RMW,
+                    new UpdateItemRequest
+                    {
+                        TableName = "test",
+                        Key = key,
+                        AttributeUpdates = new Dictionary<string, AttributeValueUpdate>
+                        {
+                            ["tags"] = new AttributeValueUpdate
+                            {
+                                Action = AttributeAction.DELETE,
+                                Value = new AttributeValue
+                                {
+                                    SS = new List<string> { "tag1" },
+                                },
+                            },
+                        },
+                    }),
+                Is.True);
+            Assert.That(
+                KeyAffinityRequestClassifier.shouldApply(
+                    KeyRouteAffinity.RMW,
+                    new UpdateItemRequest
+                    {
+                        TableName = "test",
+                        Key = key,
+                        AttributeUpdates = new Dictionary<string, AttributeValueUpdate>
+                        {
+                            ["tags"] = new AttributeValueUpdate
+                            {
+                                Action = AttributeAction.DELETE,
+                            },
+                        },
+                    }),
+                Is.False);
+
+            Assert.That(
+                KeyAffinityRequestClassifier.shouldApply(
+                    KeyRouteAffinity.RMW,
+                    new PutItemRequest
+                    {
+                        TableName = "test",
+                        Item = item,
+                    }),
+                Is.False);
+            Assert.That(
+                KeyAffinityRequestClassifier.shouldApply(
+                    KeyRouteAffinity.RMW,
+                    new PutItemRequest
+                    {
+                        TableName = "test",
+                        Item = item,
+                        ConditionExpression = "attribute_not_exists(pk)",
+                    }),
+                Is.True);
+            Assert.That(
+                KeyAffinityRequestClassifier.shouldApply(
+                    KeyRouteAffinity.RMW,
+                    new DeleteItemRequest
+                    {
+                        TableName = "test",
+                        Key = key,
+                    }),
+                Is.False);
+            Assert.That(
+                KeyAffinityRequestClassifier.shouldApply(
+                    KeyRouteAffinity.RMW,
+                    new DeleteItemRequest
+                    {
+                        TableName = "test",
+                        Key = key,
+                        ReturnValues = ReturnValue.ALL_OLD,
+                    }),
+                Is.True);
+
+            Assert.That(
+                KeyAffinityRequestClassifier.shouldApply(
+                    KeyRouteAffinity.ANY_WRITE,
+                    new QueryRequest { TableName = "test" }),
+                Is.False);
+            Assert.That(
+                KeyAffinityRequestClassifier.shouldApply(
+                    KeyRouteAffinity.ANY_WRITE,
+                    new BatchWriteItemRequest()),
+                Is.False);
+        }
+
+        [Test]
+        public void BatchWriteItemRoutingTargetsUseJavaDeterministicOrderTest()
+        {
+            var request = BatchWrite(
+                Table(
+                    "orders",
+                    Delete(Attributes("pk", StringAttribute("delete-key"))),
+                    Put(Attributes("pk", StringAttribute("put-key"), "data", StringAttribute("value")))));
+
+            var targets = KeyAffinityRequestClassifier.extractBatchWriteRoutingTargets(request);
+            var firstPartitionKey = targets[0].partitionKeyValue("pk");
+            var secondPartitionKey = targets[1].partitionKeyValue("pk");
+
+            Assert.That(targets, Has.Count.EqualTo(2));
+            Assert.That(targets[0].tableName(), Is.EqualTo("orders"));
+            Assert.That(targets[0].operation(), Is.EqualTo("PutRequest"));
+            Assert.That(firstPartitionKey, Is.Not.Null);
+            Assert.That(firstPartitionKey!.S, Is.EqualTo("put-key"));
+            Assert.That(targets[1].tableName(), Is.EqualTo("orders"));
+            Assert.That(targets[1].operation(), Is.EqualTo("DeleteRequest"));
+            Assert.That(secondPartitionKey, Is.Not.Null);
+            Assert.That(secondPartitionKey!.S, Is.EqualTo("delete-key"));
+            Assert.Throws<NotSupportedException>(() =>
+                ((IList<KeyAffinityRequestClassifier.BatchWriteRoutingTarget>)targets).Clear());
+        }
+
+        [Test]
+        public void PartitionKeyResolverSupportsJavaStyleCloseAliasTest()
+        {
+            var resolver = new PartitionKeyResolver(new Dictionary<string, string>
+            {
+                ["users"] = "user_id",
+            });
+
+            Assert.That(resolver.getPartitionKeyName("users"), Is.EqualTo("user_id"));
+            Assert.DoesNotThrow(() => resolver.close());
+            Assert.DoesNotThrow(() => resolver.close());
+        }
+
+        [Test]
+        public async Task PartitionKeyResolverDiscoversPartitionKeyTest()
+        {
+            var attempts = 0;
+            using var resolver = CreatePartitionKeyResolver(
+                null,
+                (tableName, cancellationToken) =>
+                {
+                    attempts++;
+                    return Task.FromResult(CreateDescribeTableResponse("session_id"));
+                });
+
+            resolver.TriggerDiscovery("sessions");
+
+            await WaitUntilAsync(() => resolver.GetPartitionKeyName("sessions") != null);
+            Assert.That(resolver.GetPartitionKeyName("sessions"), Is.EqualTo("session_id"));
+            Assert.That(attempts, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task PartitionKeyResolverSuppressesConcurrentDiscoveryForSameTableTest()
+        {
+            var attempts = 0;
+            var releaseDiscovery = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var resolver = CreatePartitionKeyResolver(
+                null,
+                async (tableName, cancellationToken) =>
+                {
+                    attempts++;
+                    await releaseDiscovery.Task.WaitAsync(cancellationToken);
+                    return CreateDescribeTableResponse("user_id");
+                });
+
+            resolver.TriggerDiscovery("users");
+            resolver.TriggerDiscovery("users");
+            resolver.TriggerDiscovery("users");
+
+            await WaitUntilAsync(() => attempts == 1);
+            releaseDiscovery.SetResult();
+            await WaitUntilAsync(() => resolver.GetPartitionKeyName("users") != null);
+
+            Assert.That(resolver.GetPartitionKeyName("users"), Is.EqualTo("user_id"));
+            Assert.That(attempts, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task PartitionKeyResolverPermanentFailureCooldownBlocksRediscoveryTest()
+        {
+            var attempts = 0;
+            using var resolver = CreatePartitionKeyResolver(
+                null,
+                (tableName, cancellationToken) =>
+                {
+                    attempts++;
+                    throw new ResourceNotFoundException("Table not found");
+                });
+
+            resolver.TriggerDiscovery("missing");
+            await WaitUntilAsync(() => resolver.IsInFailureCooldown("missing"));
+            var attemptsAfterFailure = attempts;
+
+            resolver.TriggerDiscovery("missing");
+            await Task.Delay(100);
+
+            Assert.That(resolver.GetPartitionKeyName("missing"), Is.Null);
+            Assert.That(attempts, Is.EqualTo(attemptsAfterFailure));
+            Assert.That(resolver.GetFailedTableCount(), Is.EqualTo(1));
+
+            resolver.ClearFailure("missing");
+            Assert.That(resolver.IsInFailureCooldown("missing"), Is.False);
+        }
+
+        [Test]
+        public void QueryPlanPipelineHandlerReusesPlanAcrossRetriesTest()
+        {
+            var helper = CreateHelperForNodes("node1", "node2", "node3");
+            var handler = CreateQueryPlanPipelineHandler(helper, null, null);
+            var contextAttributes = new Dictionary<string, object>();
+            var request = new ListTablesRequest();
+
+            var queryPlan = InvokeGetOrCreateQueryPlan(handler, request, contextAttributes);
+            var sameQueryPlan = InvokeGetOrCreateQueryPlan(handler, request, contextAttributes);
+            var hosts = DrainQueryPlanHosts(queryPlan, 3);
+
+            Assert.That(handler.getLiveNodes(), Is.SameAs(helper.getAlternatorLiveNodes()));
+            Assert.That(handler.getConfig(), Is.Null);
+            Assert.That(handler.getPartitionKeyResolver(), Is.Null);
+            Assert.That(sameQueryPlan, Is.SameAs(queryPlan));
+            Assert.That(hosts, Is.EquivalentTo(new[] { "node1", "node2", "node3" }));
+        }
+
+        [Test]
+        public void BasicQueryPlanInterceptorSupportsJavaStylePublicApiTest()
+        {
+            var liveNodes = new AlternatorLiveNodes(
+                new List<string> { "node1", "node2", "node3" },
+                "http",
+                8043,
+                ClusterScope.create());
+            var interceptor = new BasicQueryPlanInterceptor(liveNodes);
+            var contextAttributes = new Dictionary<string, object>();
+            var request = new ListTablesRequest();
+
+            var queryPlan = interceptor.GetOrCreateQueryPlan(request, contextAttributes);
+            var sameQueryPlan = interceptor.GetOrCreateQueryPlan(request, contextAttributes);
+            var hosts = DrainQueryPlanHosts(queryPlan, 3);
+
+            Assert.That(interceptor.getLiveNodes(), Is.SameAs(liveNodes));
+            Assert.That(sameQueryPlan, Is.SameAs(queryPlan));
+            Assert.That(hosts, Is.EquivalentTo(new[] { "node1", "node2", "node3" }));
+        }
+
+        [Test]
+        public void AffinityQueryPlanInterceptorSupportsJavaStylePublicApiTest()
+        {
+            var liveNodes = new AlternatorLiveNodes(
+                new List<string> { "node1", "node2", "node3", "node4", "node5" },
+                "http",
+                8043,
+                ClusterScope.create());
+            var affinity = KeyRouteAffinityConfig.builder()
+                .withType(KeyRouteAffinity.ANY_WRITE)
+                .withPkInfo("users", "user_id")
+                .build();
+            var interceptor = new AffinityQueryPlanInterceptor(affinity, liveNodes);
+            var request = new PutItemRequest
+            {
+                TableName = "users",
+                Item = new Dictionary<string, AttributeValue>
+                {
+                    ["user_id"] = new AttributeValue { S = "alice" },
+                },
+            };
+            var expectedPlan = new LazyQueryPlan(liveNodes, AttributeValueHasher.Hash(request.Item["user_id"]));
+
+            var actualPlan = interceptor.GetOrCreateQueryPlan(request, new Dictionary<string, object>());
+
+            Assert.That(interceptor.getLiveNodes(), Is.SameAs(liveNodes));
+            Assert.That(interceptor.getConfig(), Is.SameAs(affinity));
+            Assert.That(interceptor.getPartitionKeyResolver(), Is.Not.Null);
+            Assert.That(interceptor.getPartitionKeyResolver() !.getPartitionKeyName("users"), Is.EqualTo("user_id"));
+            Assert.That(DrainQueryPlanUris(actualPlan, 5), Is.EqualTo(DrainQueryPlanUris(expectedPlan, 5)));
+        }
+
+        [Test]
+        public void QueryPlanPipelineHandlerUsesStableAffinityPlanWhenPartitionKeyKnownTest()
+        {
+            var helper = CreateHelperForNodes("node1", "node2", "node3", "node4", "node5", "node6", "node7", "node8", "node9", "node10");
+            var affinity = KeyRouteAffinityConfig.builder()
+                .withType(KeyRouteAffinity.ANY_WRITE)
+                .withPkInfo("users", "user_id")
+                .build();
+            using var resolver = new PartitionKeyResolver(affinity.PkInfoPerTable.ToDictionary(item => item.Key, item => item.Value));
+            var handler = CreateQueryPlanPipelineHandler(helper, affinity, resolver);
+            var request = new PutItemRequest
+            {
+                TableName = "users",
+                Item = new Dictionary<string, AttributeValue>
+                {
+                    ["user_id"] = new AttributeValue { S = "alice" },
+                },
+            };
+            var expectedPlan = InvokeCreateQueryPlan(helper, AttributeValueHasher.Hash(request.Item["user_id"]));
+
+            var actualPlan = InvokeGetOrCreateQueryPlan(handler, request, new Dictionary<string, object>());
+
+            Assert.That(handler.getConfig(), Is.SameAs(affinity));
+            Assert.That(handler.getPartitionKeyResolver(), Is.SameAs(resolver));
+            Assert.That(DrainQueryPlanUris(actualPlan, 10), Is.EqualTo(DrainQueryPlanUris(expectedPlan, 10)));
+        }
+
+        [Test]
+        public void QueryPlanPipelineHandlerUsesBatchWriteAffinityPlanTest()
+        {
+            var helper = CreateHelperForNodes("node1", "node2", "node3", "node4", "node5", "node6", "node7", "node8", "node9", "node10");
+            var affinity = KeyRouteAffinityConfig.builder()
+                .withType(KeyRouteAffinity.ANY_WRITE)
+                .withPkInfo("orders", "pk")
+                .build();
+            using var resolver = new PartitionKeyResolver(affinity.PkInfoPerTable.ToDictionary(item => item.Key, item => item.Value));
+            var handler = CreateQueryPlanPipelineHandler(helper, affinity, resolver);
+            var request = BatchWrite(
+                Table("orders", Put(Attributes("pk", StringAttribute("order456"))), Put(Attributes("pk", StringAttribute("order123")))));
+            var expectedPlan = InvokeCreateQueryPlan(helper, BatchWriteHash(request, affinity.PkInfoPerTable));
+
+            var actualPlan = InvokeGetOrCreateQueryPlan(handler, request, new Dictionary<string, object>());
+
+            Assert.That(DrainQueryPlanUris(actualPlan, 10), Is.EqualTo(DrainQueryPlanUris(expectedPlan, 10)));
+        }
+
+        [Test]
+        public void QueryPlanPipelineHandlerBatchWriteUsesFirstDeterministicCandidateTest()
+        {
+            var helper = CreateHelperForNodes("node1", "node2", "node3", "node4", "node5");
+            var affinity = KeyRouteAffinityConfig.builder()
+                .withType(KeyRouteAffinity.ANY_WRITE)
+                .withPkInfo("orders", "pk")
+                .build();
+            using var resolver = new PartitionKeyResolver(affinity.PkInfoPerTable.ToDictionary(item => item.Key, item => item.Value));
+            var handler = CreateQueryPlanPipelineHandler(helper, affinity, resolver);
+            var majorityPk = "test-pk-value-123";
+            var otherPk = FindPkValueWithDifferentRoute(helper, "other-route-", majorityPk);
+            var request = BatchWrite(
+                Table(
+                    "orders",
+                    Put(Attributes("pk", StringAttribute(otherPk))),
+                    Put(Attributes("pk", StringAttribute(majorityPk))),
+                    Delete(Attributes("pk", StringAttribute(majorityPk)))));
+            var expectedRoute = DrainQueryPlanUris(InvokeCreateQueryPlan(helper, BatchWriteHash(request, affinity.PkInfoPerTable)), 1)[0];
+
+            var actualPlan = InvokeGetOrCreateQueryPlan(handler, request, new Dictionary<string, object>());
+
+            Assert.That(DrainQueryPlanUris(actualPlan, 1)[0], Is.EqualTo(expectedRoute));
+        }
+
+        [Test]
+        public void QueryPlanPipelineHandlerBatchWriteCandidatesUseJavaDeterministicOrderTest()
+        {
+            var helper = CreateHelperForNodes("node1", "node2", "node3", "node4", "node5");
+            var affinity = KeyRouteAffinityConfig.builder()
+                .withType(KeyRouteAffinity.ANY_WRITE)
+                .withPkInfo("orders", "pk")
+                .build();
+            using var resolver = new PartitionKeyResolver(affinity.PkInfoPerTable.ToDictionary(item => item.Key, item => item.Value));
+            var handler = CreateQueryPlanPipelineHandler(helper, affinity, resolver);
+            var firstPk = "test-pk-value-123";
+            var secondPk = FindPkValueWithDifferentRoute(helper, "tie-route-", firstPk);
+            var request = BatchWrite(
+                Table(
+                    "orders",
+                    Put(Attributes("pk", StringAttribute(firstPk))),
+                    Put(Attributes("pk", StringAttribute(secondPk)))));
+            var expectedRoute = DrainQueryPlanUris(InvokeCreateQueryPlan(helper, BatchWriteHash(request, affinity.PkInfoPerTable)), 1)[0];
+
+            var actualPlan = InvokeGetOrCreateQueryPlan(handler, request, new Dictionary<string, object>());
+
+            Assert.That(DrainQueryPlanUris(actualPlan, 1)[0], Is.EqualTo(expectedRoute));
+        }
+
+        [Test]
+        public async Task QueryPlanPipelineHandlerBatchWriteStopsAtMissingMetadataAndFallsBackToBasicPlanTest()
+        {
+            var attempts = 0;
+            var helper = CreateHelperForNodes("node1", "node2", "node3", "node4", "node5");
+            var affinity = KeyRouteAffinityConfig.builder()
+                .withType(KeyRouteAffinity.ANY_WRITE)
+                .withPkInfo("orders", "pk")
+                .build();
+            using var resolver = CreatePartitionKeyResolver(
+                affinity.PkInfoPerTable.ToDictionary(item => item.Key, item => item.Value),
+                (tableName, cancellationToken) =>
+                {
+                    attempts++;
+                    return Task.FromResult(CreateDescribeTableResponse("pk"));
+                });
+            var handler = CreateQueryPlanPipelineHandler(helper, affinity, resolver);
+            var request = BatchWrite(
+                Table("aaa_unknown_table", Put(Attributes("pk", StringAttribute("unknown-pk")))),
+                Table("orders", Put(Attributes("pk", StringAttribute("test-pk-value-123")))));
+
+            var actualPlan = InvokeGetOrCreateQueryPlan(handler, request, new Dictionary<string, object>());
+            var hosts = DrainQueryPlanHosts(actualPlan, 5);
+
+            Assert.That(hosts, Is.EquivalentTo(new[] { "node1", "node2", "node3", "node4", "node5" }));
+            await WaitUntilAsync(() => resolver.GetPartitionKeyName("aaa_unknown_table") == "pk");
+            Assert.That(attempts, Is.EqualTo(1));
+            Assert.That(resolver.GetPartitionKeyName("aaa_unknown_table"), Is.EqualTo("pk"));
+        }
+
+        [Test]
+        public async Task QueryPlanPipelineHandlerTriggersPartitionKeyDiscoveryAndFallsBackToBasicPlanTest()
+        {
+            var attempts = 0;
+            var helper = CreateHelperForNodes("node1", "node2", "node3");
+            var affinity = KeyRouteAffinityConfig.builder()
+                .withType(KeyRouteAffinity.ANY_WRITE)
+                .build();
+            using var resolver = CreatePartitionKeyResolver(
+                null,
+                (tableName, cancellationToken) =>
+                {
+                    attempts++;
+                    return Task.FromResult(CreateDescribeTableResponse("user_id"));
+                });
+            var handler = CreateQueryPlanPipelineHandler(helper, affinity, resolver);
+            var request = new PutItemRequest
+            {
+                TableName = "users",
+                Item = new Dictionary<string, AttributeValue>
+                {
+                    ["user_id"] = new AttributeValue { S = "alice" },
+                },
+            };
+
+            var queryPlan = InvokeGetOrCreateQueryPlan(handler, request, new Dictionary<string, object>());
+            var hosts = DrainQueryPlanHosts(queryPlan, 3);
+
+            Assert.That(hosts, Is.EquivalentTo(new[] { "node1", "node2", "node3" }));
+            await WaitUntilAsync(() => resolver.GetPartitionKeyName("users") == "user_id");
+            Assert.That(attempts, Is.EqualTo(1));
+            Assert.That(resolver.GetPartitionKeyName("users"), Is.EqualTo("user_id"));
+        }
+
+        [Test]
+        public void LazyQueryPlanMatchesCrossLanguageVectorsTest()
+        {
+            AssertQueryPlan(42L, 10, new[] { "node5", "node8", "node4", "node10", "node6", "node1" });
+            AssertQueryPlan(123L, 10, new[] { "node5", "node1", "node3", "node2", "node9", "node4" });
+            AssertQueryPlan(999L, 10, new[] { "node4", "node9", "node3", "node1", "node10", "node2" });
+            AssertQueryPlan(0L, 10, new[] { "node4", "node1", "node10", "node9", "node5", "node7" });
+            AssertQueryPlan(-1L, 10, new[] { "node10", "node4", "node1", "node2", "node5", "node9" });
+            AssertQueryPlan(42L, 6, new[] { "node6", "node3", "node1", "node4", "node2", "node5" });
+            AssertQueryPlan(12345L, 10, new[] { "node3", "node4", "node1", "node6", "node5", "node7" });
+            AssertQueryPlan(long.MaxValue, 10, new[] { "node10", "node6", "node7", "node1", "node9", "node3" });
+        }
+
+        [Test]
+        public void LazyQueryPlanSupportsJavaStylePublicApiTest()
+        {
+            var liveNodes = new AlternatorLiveNodes(
+                new List<string> { "node3.example.com", "node1.example.com", "node2.example.com" },
+                "http",
+                8043,
+                ClusterScope.create());
+            var sorted = LazyQueryPlan.sortedAffinityNodes(liveNodes);
+            var preferred = LazyQueryPlan.preferredNodeForHash(liveNodes, 42L);
+            var seeded = new LazyQueryPlan(liveNodes, 42L);
+            var preferredFirst = new LazyQueryPlan(liveNodes, new[] { sorted[1] });
+
+            Assert.That(sorted.Select(uri => uri.Host), Is.EqualTo(new[] { "node1.example.com", "node2.example.com", "node3.example.com" }));
+            Assert.That(preferred, Is.EqualTo(seeded.next()));
+            Assert.That(preferredFirst.hasNext(), Is.True);
+            Assert.That(preferredFirst.next(), Is.EqualTo(sorted[1]));
+            Assert.That(preferredFirst.ToList(), Is.EqualTo(new[] { sorted[0], sorted[2] }));
+            Assert.That(preferredFirst.hasNext(), Is.False);
+
+            var iteratorPlan = new LazyQueryPlan(liveNodes, new[] { sorted[0] });
+            using var iterator = iteratorPlan.iterator();
+            Assert.That(iterator.MoveNext(), Is.True);
+            Assert.That(iterator.Current, Is.EqualTo(sorted[0]));
+        }
+
+        [Test]
+        public void LazyQueryPlanSeededAffinityUsesSortedNodeOrderLikeJavaTest()
+        {
+            var unsortedLiveNodes = new AlternatorLiveNodes(
+                new List<string> { "node3.example.com", "node1.example.com", "node2.example.com" },
+                "http",
+                8043,
+                ClusterScope.create());
+            var sortedLiveNodes = new AlternatorLiveNodes(
+                new List<string> { "node1.example.com", "node2.example.com", "node3.example.com" },
+                "http",
+                8043,
+                ClusterScope.create());
+            var unsortedPlan = new LazyQueryPlan(unsortedLiveNodes, 42L);
+            var sortedPlan = new LazyQueryPlan(sortedLiveNodes, 42L);
+
+            Assert.That(unsortedPlan.ToList(), Is.EqualTo(sortedPlan.ToList()));
+            Assert.That(
+                LazyQueryPlan.preferredNodeForHash(unsortedLiveNodes, 42L),
+                Is.EqualTo(LazyQueryPlan.preferredNodeForHash(sortedLiveNodes, 42L)));
+        }
+
+        private static Helper CreateHelperForNodes(params string[] hosts)
+        {
+            var config = AlternatorConfig.builder()
+                .WithSeedHosts(hosts)
+                .WithScheme("http")
+                .WithPort(8043)
+                .Build();
+            var constructor = typeof(Helper).GetConstructor(
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                null,
+                new[] { typeof(AlternatorConfig), typeof(bool), typeof(bool), typeof(CancellationToken) },
+                null);
+            Assert.That(constructor, Is.Not.Null);
+            return (Helper)constructor!.Invoke(new object[] { config, false, false, CancellationToken.None });
+        }
+
+        private static QueryPlanPipelineHandler CreateQueryPlanPipelineHandler(
+            Helper helper,
+            KeyRouteAffinityConfig? keyRouteAffinityConfig,
+            PartitionKeyResolver? partitionKeyResolver)
+        {
+            return new QueryPlanPipelineHandler(helper, keyRouteAffinityConfig, partitionKeyResolver);
+        }
+
+        private static object InvokeCreateQueryPlan(Helper helper, long seed)
+        {
+            var method = typeof(Helper).GetMethod(
+                "CreateQueryPlan",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                null,
+                new[] { typeof(long) },
+                null);
+            Assert.That(method, Is.Not.Null);
+            var queryPlan = method!.Invoke(helper, new object[] { seed });
+            Assert.That(queryPlan, Is.Not.Null);
+            return queryPlan!;
+        }
+
+        private static object InvokeGetOrCreateQueryPlan(
+            QueryPlanPipelineHandler handler,
+            AmazonWebServiceRequest request,
+            IDictionary<string, object> contextAttributes)
+        {
+            return handler.GetOrCreateQueryPlan(request, contextAttributes);
+        }
+
+        private static List<string> DrainQueryPlanHosts(object queryPlan, int count)
+        {
+            return DrainQueryPlanUris(queryPlan, count).Select(uri => uri.Host).ToList();
+        }
+
+        private static List<Uri> DrainQueryPlanUris(object queryPlan, int count)
+        {
+            Assert.That(queryPlan, Is.InstanceOf<LazyQueryPlan>());
+            var lazyQueryPlan = (LazyQueryPlan)queryPlan;
+            var nodes = new List<Uri>();
+            for (var index = 0; index < count; index++)
+            {
+                nodes.Add(lazyQueryPlan.next());
+            }
+
+            return nodes;
+        }
+
+        private static List<BatchWriteVector> BatchWriteVectors()
+        {
+            return new List<BatchWriteVector>
+            {
+                new BatchWriteVector(
+                    "same_table_write_order",
+                    BatchWrite(
+                        Table("orders", Put(Attributes("pk", StringAttribute("order456"))), Put(Attributes("pk", StringAttribute("order123"))))),
+                    PkInfo("orders", "pk"),
+                    "orders",
+                    "PutRequest",
+                    "S:order123",
+                    "{\"pk\":{\"S\":\"order123\"}}",
+                    -2126891002421145093L,
+                    "16319853071288406523",
+                    new List<string> { "node8", "node10", "node9", "node7", "node6", "node4" }),
+                new BatchWriteVector(
+                    "multi_table_order",
+                    BatchWrite(
+                        Table("sessions", Delete(Attributes("pk", StringAttribute("session123")))),
+                        Table(
+                            "orders",
+                            Put(Attributes("data", StringAttribute("value"), "pk", StringAttribute("order456"))),
+                            Put(Attributes("pk", StringAttribute("order123"), "data", StringAttribute("value"))))),
+                    PkInfo("orders", "pk", "sessions", "pk"),
+                    "orders",
+                    "PutRequest",
+                    "S:order123",
+                    "{\"data\":{\"S\":\"value\"},\"pk\":{\"S\":\"order123\"}}",
+                    -2126891002421145093L,
+                    "16319853071288406523",
+                    new List<string> { "node8", "node10", "node9", "node7", "node6", "node4" }),
+                new BatchWriteVector(
+                    "delete_put_same_attributes",
+                    BatchWrite(
+                        Table("orders", Put(Attributes("pk", StringAttribute("same"))), Delete(Attributes("pk", StringAttribute("same"))))),
+                    PkInfo("orders", "pk"),
+                    "orders",
+                    "DeleteRequest",
+                    "S:same",
+                    "{\"pk\":{\"S\":\"same\"}}",
+                    -4879317772220196571L,
+                    "13567426301489355045",
+                    new List<string> { "node1", "node2", "node9", "node6", "node3", "node4" }),
+                new BatchWriteVector(
+                    "number_partition_key",
+                    BatchWrite(Table("accounts", Put(Attributes("pk", NumberAttribute("7"))), Put(Attributes("pk", NumberAttribute("42"))))),
+                    PkInfo("accounts", "pk"),
+                    "accounts",
+                    "PutRequest",
+                    "N:42",
+                    "{\"pk\":{\"N\":\"42\"}}",
+                    -5061732451827723051L,
+                    "13385011621881828565",
+                    new List<string> { "node2", "node6", "node1", "node9", "node10", "node4" }),
+                new BatchWriteVector(
+                    "binary_partition_key",
+                    BatchWrite(
+                        Table(
+                            "blobs",
+                            Put(Attributes("pk", BinaryAttribute(0x01, 0x02, 0x03))),
+                            Delete(Attributes("pk", BinaryAttribute(0x00, 0xff))))),
+                    PkInfo("blobs", "pk"),
+                    "blobs",
+                    "DeleteRequest",
+                    "B:00ff",
+                    "{\"pk\":{\"B\":{\"__bytes__\":\"00ff\"}}}",
+                    -4376945693382523102L,
+                    "14069798380327028514",
+                    new List<string> { "node6", "node10", "node4", "node1", "node5", "node8" }),
+            };
+        }
+
+        private static BatchWriteItemRequest BatchWrite(params KeyValuePair<string, List<WriteRequest>>[] tables)
+        {
+            var requestItems = new Dictionary<string, List<WriteRequest>>();
+            foreach (var table in tables)
+            {
+                requestItems[table.Key] = table.Value;
+            }
+
+            return new BatchWriteItemRequest { RequestItems = requestItems };
+        }
+
+        private static long BatchWriteHash(BatchWriteItemRequest request, IReadOnlyDictionary<string, string> pkInfo)
+        {
+            foreach (var target in KeyAffinityRequestClassifier.ExtractBatchWriteRoutingTargets(request))
+            {
+                var partitionKeyValue = target.PartitionKeyValue(pkInfo[target.TableName]);
+                if (partitionKeyValue == null)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    return AttributeValueHasher.Hash(partitionKeyValue);
+                }
+                catch (ArgumentException)
+                {
+                }
+            }
+
+            throw new AssertionException("Batch write request does not have a usable partition key value.");
+        }
+
+        private static Uri FirstAffinityRouteForPk(Helper helper, string partitionKeyValue)
+        {
+            return LazyQueryPlan.preferredNodeForHash(
+                helper.getAlternatorLiveNodes(),
+                AttributeValueHasher.hash(StringAttribute(partitionKeyValue))) !;
+        }
+
+        private static string FindPkValueWithDifferentRoute(Helper helper, string prefix, string otherPartitionKeyValue)
+        {
+            var otherRoute = FirstAffinityRouteForPk(helper, otherPartitionKeyValue);
+            for (var index = 0; index < 100; index++)
+            {
+                var candidate = prefix + index;
+                if (!FirstAffinityRouteForPk(helper, candidate).Equals(otherRoute))
+                {
+                    return candidate;
+                }
+            }
+
+            throw new AssertionException("Could not find test partition key with a different affinity route.");
+        }
+
+        private static AttributeValue BinaryAttribute(params int[] values)
+        {
+            return new AttributeValue { B = new MemoryStream(values.Select(value => (byte)value).ToArray()) };
+        }
+
+        private static WriteRequest Delete(Dictionary<string, AttributeValue> key)
+        {
+            return new WriteRequest { DeleteRequest = new DeleteRequest { Key = key } };
+        }
+
+        private static Dictionary<string, AttributeValue> Attributes(params object[] keyValues)
+        {
+            var attributes = new Dictionary<string, AttributeValue>();
+            for (var index = 0; index < keyValues.Length; index += 2)
+            {
+                attributes[(string)keyValues[index]] = (AttributeValue)keyValues[index + 1];
+            }
+
+            return attributes;
+        }
+
+        private static AttributeValue NumberAttribute(string value)
+        {
+            return new AttributeValue { N = value };
+        }
+
+        private static List<string> NodeSequence(long seed, int count)
+        {
+            var helper = CreateHelperForNodes(Enumerable.Range(1, 10).Select(index => $"node{index}.example.com").ToArray());
+            return DrainQueryPlanUris(InvokeCreateQueryPlan(helper, seed), count)
+                .Select(uri => uri.Host.Substring(0, uri.Host.IndexOf(".example.com", StringComparison.Ordinal)))
+                .ToList();
+        }
+
+        private static Dictionary<string, string> PkInfo(string tableName, string pkName, params string[] rest)
+        {
+            var pkInfo = new Dictionary<string, string>
+            {
+                [tableName] = pkName,
+            };
+            for (var index = 0; index < rest.Length; index += 2)
+            {
+                pkInfo[rest[index]] = rest[index + 1];
+            }
+
+            return pkInfo;
+        }
+
+        private static WriteRequest Put(Dictionary<string, AttributeValue> item)
+        {
+            return new WriteRequest { PutRequest = new PutRequest { Item = item } };
+        }
+
+        private static AttributeValue StringAttribute(string value)
+        {
+            return new AttributeValue { S = value };
+        }
+
+        private static KeyValuePair<string, List<WriteRequest>> Table(string tableName, params WriteRequest[] writes)
+        {
+            return new KeyValuePair<string, List<WriteRequest>>(tableName, writes.ToList());
+        }
+
+        private static string AttributeLabel(AttributeValue? value)
+        {
+            if (value?.S != null)
+            {
+                return "S:" + value.S;
+            }
+
+            if (value?.N != null)
+            {
+                return "N:" + value.N;
+            }
+
+            if (value?.B != null)
+            {
+                return "B:" + Hex(value.B.ToArray());
+            }
+
+            return value?.ToString() ?? string.Empty;
+        }
+
+        private static string Hex(byte[] bytes)
+        {
+            const string HexDigits = "0123456789abcdef";
+            var chars = new char[bytes.Length * 2];
+            for (var index = 0; index < bytes.Length; index++)
+            {
+                chars[index * 2] = HexDigits[(bytes[index] >> 4) & 0x0f];
+                chars[(index * 2) + 1] = HexDigits[bytes[index] & 0x0f];
+            }
+
+            return new string(chars);
+        }
+
+        private static void AssertQueryPlan(long seed, int nodeCount, string[] expectedHosts)
+        {
+            var nodes = Enumerable.Range(1, nodeCount).Select(index => new Uri($"http://node{index}.example.com:8043")).ToList();
+            var queryPlan = new LazyQueryPlan(nodes, seed);
+            var actualHosts = new List<string>();
+            for (var index = 0; index < expectedHosts.Length; index++)
+            {
+                var host = queryPlan.next().Host;
+                actualHosts.Add(host.Substring(0, host.IndexOf(".example.com", StringComparison.Ordinal)));
+            }
+
+            Assert.That(actualHosts, Is.EqualTo(expectedHosts));
+        }
+
+        private static PartitionKeyResolver CreatePartitionKeyResolver(
+            IDictionary<string, string>? preConfigured,
+            Func<string, CancellationToken, Task<DescribeTableResponse>> describeTableAsync)
+        {
+            var constructor = typeof(PartitionKeyResolver).GetConstructor(
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                null,
+                new[] { typeof(IDictionary<string, string>), typeof(Func<string, CancellationToken, Task<DescribeTableResponse>>) },
+                null);
+            Assert.That(constructor, Is.Not.Null);
+            return (PartitionKeyResolver)constructor!.Invoke(new object?[] { preConfigured, describeTableAsync });
+        }
+
+        private static DescribeTableResponse CreateDescribeTableResponse(string partitionKeyName)
+        {
+            return new DescribeTableResponse
+            {
+                Table = new TableDescription
+                {
+                    KeySchema = new List<KeySchemaElement>
+                    {
+                        new KeySchemaElement
+                        {
+                            AttributeName = partitionKeyName,
+                            KeyType = KeyType.HASH,
+                        },
+                        new KeySchemaElement
+                        {
+                            AttributeName = "sort_key",
+                            KeyType = KeyType.RANGE,
+                        },
+                    },
+                },
+            };
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> condition)
+        {
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            while (!condition())
+            {
+                cancellation.Token.ThrowIfCancellationRequested();
+                await Task.Delay(20, cancellation.Token);
+            }
+        }
+
+        private sealed class BatchWriteVector
+        {
+            internal BatchWriteVector(
+                string name,
+                BatchWriteItemRequest request,
+                IReadOnlyDictionary<string, string> pkInfo,
+                string tableName,
+                string operation,
+                string partitionKeyLabel,
+                string canonicalAttributes,
+                long hashSigned,
+                string hashUnsigned,
+                List<string> firstSixNodes)
+            {
+                this.Name = name;
+                this.Request = request;
+                this.PkInfo = pkInfo;
+                this.TableName = tableName;
+                this.Operation = operation;
+                this.PartitionKeyLabel = partitionKeyLabel;
+                this.CanonicalAttributes = canonicalAttributes;
+                this.HashSigned = hashSigned;
+                this.HashUnsigned = hashUnsigned;
+                this.FirstSixNodes = firstSixNodes;
+            }
+
+            internal string Name { get; }
+
+            internal BatchWriteItemRequest Request { get; }
+
+            internal IReadOnlyDictionary<string, string> PkInfo { get; }
+
+            internal string TableName { get; }
+
+            internal string Operation { get; }
+
+            internal string PartitionKeyLabel { get; }
+
+            internal string CanonicalAttributes { get; }
+
+            internal long HashSigned { get; }
+
+            internal string HashUnsigned { get; }
+
+            internal List<string> FirstSixNodes { get; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add basic and affinity query-plan pipeline handlers
- add key-routing hash, request classification, batch-write target selection, and partition-key discovery support
- add focused unit coverage for cross-language hash vectors, deterministic routing, discovery cooldowns, and query-plan reuse

## Verification
- dotnet restore ScyllaDB.Alternator.sln --verbosity minimal
- make build
- make check
- make test-unit