### PR TITLE
Add Alternator DynamoDB client builder

### DIFF
--- a/AlternatorAmazonDynamoDBClient.cs
+++ b/AlternatorAmazonDynamoDBClient.cs
@@ -1,0 +1,126 @@
+// <copyright file="AlternatorAmazonDynamoDBClient.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    using Amazon.DynamoDBv2;
+    using Amazon.Runtime;
+    using Amazon.Runtime.Internal;
+    using ScyllaDB.Alternator.KeyRouting;
+
+    internal sealed class AlternatorAmazonDynamoDBClient : AmazonDynamoDBClient
+    {
+        private static readonly AsyncLocal<AlternatorConfig?> ConstructionConfig = new AsyncLocal<AlternatorConfig?>();
+        private static readonly AsyncLocal<Helper?> ConstructionEndpointProvider = new AsyncLocal<Helper?>();
+        private static readonly AsyncLocal<PartitionKeyResolver?> ConstructionPartitionKeyResolver = new AsyncLocal<PartitionKeyResolver?>();
+        private static readonly AsyncLocal<Func<string, string?>?> ConstructionUserAgentTransformer = new AsyncLocal<Func<string, string?>?>();
+        private static readonly AsyncLocal<bool> ConstructionAppendDefaultUserAgentToken = new AsyncLocal<bool>();
+        private readonly AlternatorConfig? alternatorConfig;
+        private readonly Helper? endpointProvider;
+        private readonly PartitionKeyResolver? partitionKeyResolver;
+        private readonly bool appendDefaultUserAgentToken;
+        private readonly Func<string, string?>? userAgentTransformer;
+        private int disposeSignaled;
+
+        private AlternatorAmazonDynamoDBClient(
+            AWSCredentials credentials,
+            AmazonDynamoDBConfig clientConfig,
+            AlternatorConfig alternatorConfig,
+            Helper endpointProvider,
+            PartitionKeyResolver? partitionKeyResolver,
+            Func<string, string?>? userAgentTransformer,
+            bool appendDefaultUserAgentToken)
+            : base(credentials, clientConfig)
+        {
+            this.alternatorConfig = alternatorConfig;
+            this.endpointProvider = endpointProvider;
+            this.partitionKeyResolver = partitionKeyResolver;
+            this.userAgentTransformer = userAgentTransformer;
+            this.appendDefaultUserAgentToken = appendDefaultUserAgentToken;
+        }
+
+        internal static AlternatorAmazonDynamoDBClient Create(
+            AWSCredentials credentials,
+            AmazonDynamoDBConfig clientConfig,
+            AlternatorConfig alternatorConfig,
+            Helper endpointProvider,
+            PartitionKeyResolver? partitionKeyResolver,
+            Func<string, string?>? userAgentTransformer,
+            bool appendDefaultUserAgentToken)
+        {
+            var previousConfig = ConstructionConfig.Value;
+            var previousEndpointProvider = ConstructionEndpointProvider.Value;
+            var previousPartitionKeyResolver = ConstructionPartitionKeyResolver.Value;
+            var previousUserAgentTransformer = ConstructionUserAgentTransformer.Value;
+            var previousAppendDefaultUserAgentToken = ConstructionAppendDefaultUserAgentToken.Value;
+            ConstructionConfig.Value = alternatorConfig;
+            ConstructionEndpointProvider.Value = endpointProvider;
+            ConstructionPartitionKeyResolver.Value = partitionKeyResolver;
+            ConstructionUserAgentTransformer.Value = userAgentTransformer;
+            ConstructionAppendDefaultUserAgentToken.Value = appendDefaultUserAgentToken;
+            try
+            {
+                return new AlternatorAmazonDynamoDBClient(
+                    credentials,
+                    clientConfig,
+                    alternatorConfig,
+                    endpointProvider,
+                    partitionKeyResolver,
+                    userAgentTransformer,
+                    appendDefaultUserAgentToken);
+            }
+            finally
+            {
+                ConstructionConfig.Value = previousConfig;
+                ConstructionEndpointProvider.Value = previousEndpointProvider;
+                ConstructionPartitionKeyResolver.Value = previousPartitionKeyResolver;
+                ConstructionUserAgentTransformer.Value = previousUserAgentTransformer;
+                ConstructionAppendDefaultUserAgentToken.Value = previousAppendDefaultUserAgentToken;
+            }
+        }
+
+        protected override void CustomizeRuntimePipeline(RuntimePipeline pipeline)
+        {
+            base.CustomizeRuntimePipeline(pipeline);
+            var config = this.alternatorConfig ?? ConstructionConfig.Value;
+            var userAgentTransformer = this.userAgentTransformer ?? ConstructionUserAgentTransformer.Value;
+            var appendDefaultUserAgentToken = this.appendDefaultUserAgentToken || ConstructionAppendDefaultUserAgentToken.Value;
+            if (userAgentTransformer != null || (config?.UserAgentEnabled == true && appendDefaultUserAgentToken))
+            {
+                pipeline.AddHandlerBefore<Signer>(new AlternatorUserAgentPipelineHandler(userAgentTransformer, appendDefaultUserAgentToken));
+            }
+
+            if (config != null && config.CompressionAlgorithm == RequestCompressionAlgorithm.Gzip)
+            {
+                pipeline.AddHandlerBefore<CompressionHandler>(new GzipRequestPipelineHandler(config.MinCompressionSizeBytes));
+            }
+
+            var helper = this.endpointProvider ?? ConstructionEndpointProvider.Value;
+            if (helper != null)
+            {
+                var resolver = this.partitionKeyResolver ?? ConstructionPartitionKeyResolver.Value;
+                var liveNodes = helper.GetAlternatorLiveNodes();
+                if (config?.KeyRouteAffinityConfig?.IsEnabled == true && resolver != null)
+                {
+                    pipeline.AddHandlerBefore<Signer>(new AffinityQueryPlanInterceptor(config.KeyRouteAffinityConfig, liveNodes, resolver));
+                }
+                else
+                {
+                    pipeline.AddHandlerBefore<Signer>(new BasicQueryPlanInterceptor(liveNodes));
+                }
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && Interlocked.Exchange(ref this.disposeSignaled, 1) == 0)
+            {
+                this.partitionKeyResolver?.Dispose();
+                this.endpointProvider?.Stop();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/AlternatorDynamoDBClient.cs
+++ b/AlternatorDynamoDBClient.cs
@@ -1,0 +1,86 @@
+// <copyright file="AlternatorDynamoDBClient.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    using Amazon.DynamoDBv2;
+    using Amazon.Runtime;
+
+    public static class AlternatorDynamoDBClient
+    {
+        public static AlternatorDynamoDBClientBuilder Builder()
+        {
+            return new AlternatorDynamoDBClientBuilder();
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public static AlternatorDynamoDBClientBuilder builder()
+        {
+            return Builder();
+        }
+#pragma warning restore SA1300, IDE1006
+
+        public static AmazonDynamoDBClient Create(
+            AWSCredentials credentials,
+            Uri initialNodeUri,
+            string datacenter = "",
+            string rack = "")
+        {
+            return Builder()
+                .WithCredentials(credentials)
+                .WithInitialNodeUri(initialNodeUri)
+                .WithDatacenter(datacenter)
+                .WithRack(rack)
+                .Build();
+        }
+
+        public static AmazonDynamoDBClient Create(
+            Uri initialNodeUri,
+            string datacenter = "",
+            string rack = "")
+        {
+            return Builder()
+                .EndpointOverride(initialNodeUri)
+                .WithDatacenter(datacenter)
+                .WithRack(rack)
+                .Build();
+        }
+
+        public static AmazonDynamoDBClient Create(AWSCredentials credentials, HelperOptions options)
+        {
+            return Builder()
+                .WithCredentials(credentials)
+                .WithOptions(options)
+                .Build();
+        }
+
+        public static AmazonDynamoDBClient Create(AWSCredentials credentials, AlternatorConfig config)
+        {
+            return Builder(config)
+                .WithCredentials(credentials)
+                .Build();
+        }
+
+        public static AmazonDynamoDBClient Create(AlternatorConfig config)
+        {
+            return Builder(config).Build();
+        }
+
+        private static AlternatorDynamoDBClientBuilder Builder(AlternatorConfig? config)
+        {
+            var builder = Builder()
+                .WithAlternatorConfig(config);
+
+            if (config != null)
+            {
+                builder
+                    .WithInitialNodes(config.SeedHosts.ToArray())
+                    .WithSchema(config.Scheme)
+                    .WithPort(config.Port);
+            }
+
+            return builder;
+        }
+    }
+}

--- a/AlternatorDynamoDBClientBuilder.cs
+++ b/AlternatorDynamoDBClientBuilder.cs
@@ -1,0 +1,1008 @@
+// <copyright file="AlternatorDynamoDBClientBuilder.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    using Amazon;
+    using Amazon.DynamoDBv2;
+    using Amazon.Runtime;
+    using Amazon.Runtime.Endpoints;
+    using ScyllaDB.Alternator.KeyRouting;
+    using ScyllaDB.Alternator.Routing;
+
+    public class AlternatorDynamoDBClientBuilder
+    {
+        private readonly HelperOptionsBuilder optionsBuilder;
+        private readonly AlternatorConfigBuilder configBuilder;
+        private AWSCredentials? credentials;
+        private AmazonDynamoDBConfig? config;
+        private Action<AmazonDynamoDBConfig>? configureAws;
+        private HelperOptions? options;
+        private string datacenter = string.Empty;
+        private string rack = string.Empty;
+        private bool validateOnInitialization = true;
+        private bool startImmediately = true;
+        private CancellationToken cancellationToken = CancellationToken.None;
+        private Func<string, string?>? userAgentTransformer;
+        private bool defaultUserAgentTokenEnabled = true;
+        private Action<HttpClientHandler>? configureHttpClientHandler;
+        private Action<SocketsHttpHandler>? configureSocketsHttpHandler;
+        private HttpClientType httpClientType = HttpClientType.Auto;
+        private bool httpClientTypeSet;
+        private bool httpClientFactorySet;
+        private bool disableCertificateChecks;
+        private bool apacheHttpClientCustomizerSet;
+        private bool crtHttpClientCustomizerSet;
+        private bool systemNetHttpClientCustomizerSet;
+
+        public AlternatorDynamoDBClientBuilder()
+        {
+            this.optionsBuilder = HelperOptionsBuilder.Create();
+            this.configBuilder = AlternatorConfig.Builder();
+        }
+
+        public HttpClientType HttpClientType => this.httpClientType;
+
+        public AlternatorDynamoDBClientBuilder WithCredentials(AWSCredentials credentials)
+        {
+            this.credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithCredentials(string accessKey, string secretKey)
+        {
+            return this.WithCredentials(new BasicAWSCredentials(accessKey, secretKey));
+        }
+
+        public AlternatorDynamoDBClientBuilder WithCredentials(string accessKey, string secretKey, string token)
+        {
+            return this.WithCredentials(new SessionAWSCredentials(accessKey, secretKey, token));
+        }
+
+        public AlternatorDynamoDBClientBuilder WithOptions(HelperOptions options)
+        {
+            this.options = options ?? throw new ArgumentNullException(nameof(options));
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithAlternatorConfig(AlternatorConfig? config)
+        {
+            if (config == null)
+            {
+                return this;
+            }
+
+            this.options = null;
+            this.ApplyAlternatorConfig(config);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder EndpointOverride(Uri endpointOverride)
+        {
+            this.optionsBuilder.WithInitialNodeUri(endpointOverride);
+            this.configBuilder.WithSeedNode(endpointOverride);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder EndpointOverride(string endpointOverride)
+        {
+            return this.EndpointOverride(new Uri(endpointOverride));
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public AlternatorDynamoDBClientBuilder endpointOverride(Uri endpointOverride)
+        {
+            return this.EndpointOverride(endpointOverride);
+        }
+
+        public AlternatorDynamoDBClientBuilder endpointOverride(string endpointOverride)
+        {
+            return this.EndpointOverride(endpointOverride);
+        }
+
+        public AlternatorDynamoDBClientBuilder credentialsProvider(AWSCredentials credentials)
+        {
+            return this.WithCredentials(credentials);
+        }
+
+        public AlternatorDynamoDBClientBuilder credentialsProvider(string accessKey, string secretKey)
+        {
+            return this.WithCredentials(accessKey, secretKey);
+        }
+
+        public AlternatorDynamoDBClientBuilder credentialsProvider(string accessKey, string secretKey, string token)
+        {
+            return this.WithCredentials(accessKey, secretKey, token);
+        }
+
+        public AlternatorDynamoDBClientBuilder region(RegionEndpoint regionEndpoint)
+        {
+            return this.WithRegionEndpoint(regionEndpoint);
+        }
+
+        public AlternatorDynamoDBClientBuilder region(string regionSystemName)
+        {
+            return this.WithRegionEndpoint(regionSystemName);
+        }
+
+        public AlternatorDynamoDBClientBuilder withAlternatorConfig(AlternatorConfig? config)
+        {
+            return this.WithAlternatorConfig(config);
+        }
+#pragma warning restore SA1300, IDE1006
+
+        public AlternatorDynamoDBClientBuilder WithInitialNodeUri(Uri uri)
+        {
+            return this.EndpointOverride(uri);
+        }
+
+        public AlternatorDynamoDBClientBuilder WithInitialNodeUri(string uri)
+        {
+            return this.EndpointOverride(uri);
+        }
+
+        public AlternatorDynamoDBClientBuilder WithInitialNodes(List<string> initialNodes)
+        {
+            this.optionsBuilder.WithInitialNodes(initialNodes);
+            this.configBuilder.WithSeedHosts(initialNodes);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithInitialNodes(params string[] initialNodes)
+        {
+            this.optionsBuilder.WithInitialNodes(initialNodes);
+            this.configBuilder.WithSeedHosts(initialNodes);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder AddInitialNode(string node)
+        {
+            this.optionsBuilder.AddInitialNode(node);
+            this.configBuilder.WithSeedHosts(this.optionsBuilder.Build().InitialNodes);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithSchema(string schema)
+        {
+            this.optionsBuilder.WithSchema(schema);
+            this.configBuilder.WithScheme(schema);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithPort(int port)
+        {
+            this.optionsBuilder.WithPort(port);
+            this.configBuilder.WithPort(port);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithDatacenter(string datacenter)
+        {
+            this.datacenter = datacenter ?? string.Empty;
+            this.optionsBuilder.WithDatacenter(this.datacenter);
+            this.ApplyLegacyRoutingScope();
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithRack(string rack)
+        {
+            this.rack = rack ?? string.Empty;
+            this.optionsBuilder.WithRack(this.rack);
+            this.ApplyLegacyRoutingScope();
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithDatacenterAndRack(string datacenter, string rack)
+        {
+            this.datacenter = datacenter ?? string.Empty;
+            this.rack = rack ?? string.Empty;
+            this.optionsBuilder.WithDatacenterAndRack(this.datacenter, this.rack);
+            this.ApplyLegacyRoutingScope();
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithRoutingScope(RoutingScope? routingScope)
+        {
+            this.optionsBuilder.WithRoutingScope(routingScope);
+            this.configBuilder.WithRoutingScope(routingScope);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithCompressionAlgorithm(RequestCompressionAlgorithm algorithm)
+        {
+            this.configBuilder.WithCompressionAlgorithm(algorithm);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithCompressionAlgorithm(RequestCompressionAlgorithm? algorithm)
+        {
+            this.configBuilder.WithCompressionAlgorithm(algorithm);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithMinCompressionSizeBytes(int minCompressionSizeBytes)
+        {
+            this.configBuilder.WithMinCompressionSizeBytes(minCompressionSizeBytes);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithOptimizeHeaders(bool optimizeHeaders)
+        {
+            this.configBuilder.WithOptimizeHeaders(optimizeHeaders);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithHeadersWhitelist(IEnumerable<string> headers)
+        {
+            this.configBuilder.WithHeadersWhitelist(headers);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithUserAgent(string userAgent)
+        {
+            this.userAgentTransformer = AlternatorUserAgent.ReplaceWith(userAgent);
+            this.defaultUserAgentTokenEnabled = false;
+            this.configBuilder.WithUserAgentEnabled(true);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithUserAgent(Func<string, string?> userAgentTransformer)
+        {
+            this.userAgentTransformer = AlternatorUserAgent.RequireUserAgentTransformer(userAgentTransformer);
+            this.defaultUserAgentTokenEnabled = true;
+            this.configBuilder.WithUserAgentEnabled(true);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithoutUserAgent()
+        {
+            this.userAgentTransformer = AlternatorUserAgent.Disable();
+            this.defaultUserAgentTokenEnabled = false;
+            this.configBuilder.WithUserAgentEnabled(false);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithKeyRouteAffinity(KeyRouteAffinityConfig keyRouteAffinityConfig)
+        {
+            this.configBuilder.WithKeyRouteAffinity(keyRouteAffinityConfig);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithKeyRouteAffinity(KeyRouteAffinity type)
+        {
+            this.configBuilder.WithKeyRouteAffinity(type);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithKeyRouteAffinity(KeyRouteAffinity? type)
+        {
+            this.configBuilder.WithKeyRouteAffinity(type);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithActiveRefreshIntervalMs(long intervalMs)
+        {
+            this.optionsBuilder.WithActiveRefreshIntervalMs(intervalMs);
+            this.configBuilder.WithActiveRefreshIntervalMs(intervalMs);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithIdleRefreshIntervalMs(long intervalMs)
+        {
+            this.optionsBuilder.WithIdleRefreshIntervalMs(intervalMs);
+            this.configBuilder.WithIdleRefreshIntervalMs(intervalMs);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithMaxConnections(int maxConnections)
+        {
+            this.configBuilder.WithMaxConnections(maxConnections);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithConnectionMaxIdleTimeMs(long connectionMaxIdleTimeMs)
+        {
+            this.configBuilder.WithConnectionMaxIdleTimeMs(connectionMaxIdleTimeMs);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithConnectionTimeToLiveMs(long connectionTimeToLiveMs)
+        {
+            this.configBuilder.WithConnectionTimeToLiveMs(connectionTimeToLiveMs);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithConnectionAcquisitionTimeoutMs(long connectionAcquisitionTimeoutMs)
+        {
+            this.configBuilder.WithConnectionAcquisitionTimeoutMs(connectionAcquisitionTimeoutMs);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithConnectionTimeoutMs(long connectionTimeoutMs)
+        {
+            this.configBuilder.WithConnectionTimeoutMs(connectionTimeoutMs);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithTlsConfig(TlsConfig? tlsConfig)
+        {
+            this.configBuilder.WithTlsConfig(tlsConfig);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithTlsSessionCacheConfig(TlsSessionCacheConfig? tlsSessionCacheConfig)
+        {
+            this.configBuilder.WithTlsSessionCacheConfig(tlsSessionCacheConfig);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithDisableCertificateChecks()
+        {
+            this.disableCertificateChecks = true;
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithValidation(bool validate)
+        {
+            this.validateOnInitialization = validate;
+            this.optionsBuilder.WithValidation(validate);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithoutValidation()
+        {
+            this.validateOnInitialization = false;
+            this.optionsBuilder.WithoutValidation();
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithImmediateStart(bool startImmediately)
+        {
+            this.startImmediately = startImmediately;
+            this.optionsBuilder.WithImmediateStart(startImmediately);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithDeferredStart()
+        {
+            this.startImmediately = false;
+            this.optionsBuilder.WithDeferredStart();
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithCancellationToken(CancellationToken cancellationToken)
+        {
+            this.cancellationToken = cancellationToken;
+            this.optionsBuilder.WithCancellationToken(cancellationToken);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithAmazonDynamoDBConfig(AmazonDynamoDBConfig config)
+        {
+            this.config = config ?? throw new ArgumentNullException(nameof(config));
+            this.httpClientFactorySet = this.config.HttpClientFactory != null;
+            return this;
+        }
+
+        public AmazonDynamoDBConfig OverrideConfiguration()
+        {
+            return this.GetOrCreateDynamoDbConfig();
+        }
+
+        public AlternatorDynamoDBClientBuilder OverrideConfiguration(AmazonDynamoDBConfig config)
+        {
+            return this.WithAmazonDynamoDBConfig(config);
+        }
+
+        public AlternatorDynamoDBClientBuilder OverrideConfiguration(Action<AmazonDynamoDBConfig> configure)
+        {
+            (configure ?? throw new ArgumentNullException(nameof(configure))).Invoke(this.GetOrCreateDynamoDbConfig());
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithRegionEndpoint(RegionEndpoint regionEndpoint)
+        {
+            if (regionEndpoint == null)
+            {
+                throw new ArgumentNullException(nameof(regionEndpoint));
+            }
+
+            this.GetOrCreateDynamoDbConfig().RegionEndpoint = regionEndpoint;
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithRegionEndpoint(string regionSystemName)
+        {
+            if (regionSystemName == null)
+            {
+                throw new ArgumentNullException(nameof(regionSystemName));
+            }
+
+            return this.WithRegionEndpoint(RegionEndpoint.GetBySystemName(regionSystemName));
+        }
+
+        public AlternatorDynamoDBClientBuilder WithHttpClientHandlerCustomizer(Action<HttpClientHandler> customizer)
+        {
+            this.configureHttpClientHandler += customizer ?? throw new ArgumentNullException(nameof(customizer));
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithSocketsHttpHandlerCustomizer(Action<SocketsHttpHandler> customizer)
+        {
+            this.configureSocketsHttpHandler += customizer ?? throw new ArgumentNullException(nameof(customizer));
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithApacheHttpClientCustomizer(Action<HttpClientHandler> customizer)
+        {
+            if (customizer == null)
+            {
+                throw new ArgumentNullException(nameof(customizer));
+            }
+
+            this.apacheHttpClientCustomizerSet = true;
+            return this.WithHttpClientHandlerCustomizer(customizer);
+        }
+
+        public AlternatorDynamoDBClientBuilder WithCrtHttpClientCustomizer(Action<HttpClientHandler> customizer)
+        {
+            if (customizer == null)
+            {
+                throw new ArgumentNullException(nameof(customizer));
+            }
+
+            this.crtHttpClientCustomizerSet = true;
+            return this.WithHttpClientHandlerCustomizer(customizer);
+        }
+
+        public AlternatorDynamoDBClientBuilder WithSystemNetHttpClientCustomizer(Action<HttpClientHandler> customizer)
+        {
+            if (customizer == null)
+            {
+                throw new ArgumentNullException(nameof(customizer));
+            }
+
+            this.systemNetHttpClientCustomizerSet = true;
+            return this.WithHttpClientHandlerCustomizer(customizer);
+        }
+
+        public AlternatorDynamoDBClientBuilder WithHttpClientType(HttpClientType httpClientType)
+        {
+            this.httpClientType = httpClientType;
+            this.httpClientTypeSet = true;
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithHttpClientType(HttpClientType? httpClientType)
+        {
+            if (httpClientType == null)
+            {
+                throw new ArgumentNullException(nameof(httpClientType));
+            }
+
+            return this.WithHttpClientType(httpClientType.Value);
+        }
+
+        public AlternatorDynamoDBClientBuilder WithHttpClientFactory(HttpClientFactory httpClientFactory)
+        {
+            this.GetOrCreateDynamoDbConfig().HttpClientFactory =
+                httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+            this.httpClientFactorySet = true;
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder HttpClientFactory(HttpClientFactory httpClientFactory)
+        {
+            return this.WithHttpClientFactory(httpClientFactory);
+        }
+
+        public AlternatorDynamoDBClientBuilder AccountIdEndpointMode(AccountIdEndpointMode accountIdEndpointMode)
+        {
+            this.GetOrCreateDynamoDbConfig().AccountIdEndpointMode = accountIdEndpointMode;
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder EndpointProvider(IEndpointProvider endpointProvider)
+        {
+            throw new NotSupportedException(
+                "AlternatorDynamoDBClient does not support custom endpoint providers. Use EndpointOverride(Uri) to specify the seed endpoint instead.");
+        }
+
+        public AlternatorDynamoDBClientBuilder EndpointDiscoveryEnabled(bool endpointDiscoveryEnabled)
+        {
+            throw new NotSupportedException(
+                "AlternatorDynamoDBClient does not support AWS endpoint discovery. Node discovery is handled automatically via the /localnodes API.");
+        }
+
+        public AlternatorDynamoDBClientBuilder EnableEndpointDiscovery()
+        {
+            throw new NotSupportedException(
+                "AlternatorDynamoDBClient does not support AWS endpoint discovery. Node discovery is handled automatically via the /localnodes API.");
+        }
+
+        public AlternatorDynamoDBClientBuilder FipsEnabled(bool? fipsEnabled)
+        {
+            throw new NotSupportedException("AlternatorDynamoDBClient does not support FIPS mode.");
+        }
+
+        public AlternatorDynamoDBClientBuilder DualstackEnabled(bool? dualstackEnabled)
+        {
+            throw new NotSupportedException("AlternatorDynamoDBClient does not support dual-stack networking.");
+        }
+
+        public AlternatorDynamoDBClientBuilder ConfigureHttpClientHandler(Action<HttpClientHandler> configure)
+        {
+            return this.WithHttpClientHandlerCustomizer(configure);
+        }
+
+        public AlternatorDynamoDBClientBuilder ConfigureSocketsHttpHandler(Action<SocketsHttpHandler> configure)
+        {
+            return this.WithSocketsHttpHandlerCustomizer(configure);
+        }
+
+        public AlternatorDynamoDBClientBuilder ConfigureAws(Action<AmazonDynamoDBConfig> configure)
+        {
+            this.configureAws += configure ?? throw new ArgumentNullException(nameof(configure));
+            return this;
+        }
+
+        public AmazonDynamoDBClient Build()
+        {
+            return this.BuildClientArtifacts().Client;
+        }
+
+        public AlternatorDynamoDBClientWrapper BuildWithAlternatorAPI()
+        {
+            var artifacts = this.BuildClientArtifacts();
+            return new AlternatorDynamoDBClientWrapper(
+                artifacts.Client,
+                artifacts.EndpointProvider,
+                artifacts.AlternatorConfig,
+                artifacts.PartitionKeyResolver);
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public AlternatorDynamoDBClientBuilder withRoutingScope(RoutingScope? routingScope)
+        {
+            return this.WithRoutingScope(routingScope);
+        }
+
+        public AlternatorDynamoDBClientBuilder withCompressionAlgorithm(RequestCompressionAlgorithm algorithm)
+        {
+            return this.WithCompressionAlgorithm(algorithm);
+        }
+
+        public AlternatorDynamoDBClientBuilder withCompressionAlgorithm(RequestCompressionAlgorithm? algorithm)
+        {
+            return this.WithCompressionAlgorithm(algorithm);
+        }
+
+        public AlternatorDynamoDBClientBuilder withMinCompressionSizeBytes(int minCompressionSizeBytes)
+        {
+            return this.WithMinCompressionSizeBytes(minCompressionSizeBytes);
+        }
+
+        public AlternatorDynamoDBClientBuilder withOptimizeHeaders(bool optimizeHeaders)
+        {
+            return this.WithOptimizeHeaders(optimizeHeaders);
+        }
+
+        public AlternatorDynamoDBClientBuilder withHeadersWhitelist(IEnumerable<string> headers)
+        {
+            return this.WithHeadersWhitelist(headers);
+        }
+
+        public AlternatorDynamoDBClientBuilder withUserAgent(string userAgent)
+        {
+            return this.WithUserAgent(userAgent);
+        }
+
+        public AlternatorDynamoDBClientBuilder withUserAgent(Func<string, string?> userAgentTransformer)
+        {
+            return this.WithUserAgent(userAgentTransformer);
+        }
+
+        public AlternatorDynamoDBClientBuilder withoutUserAgent()
+        {
+            return this.WithoutUserAgent();
+        }
+
+        public AlternatorDynamoDBClientBuilder withKeyRouteAffinity(KeyRouteAffinityConfig keyRouteAffinityConfig)
+        {
+            return this.WithKeyRouteAffinity(keyRouteAffinityConfig);
+        }
+
+        public AlternatorDynamoDBClientBuilder withKeyRouteAffinity(KeyRouteAffinity type)
+        {
+            return this.WithKeyRouteAffinity(type);
+        }
+
+        public AlternatorDynamoDBClientBuilder withKeyRouteAffinity(KeyRouteAffinity? type)
+        {
+            return this.WithKeyRouteAffinity(type);
+        }
+
+        public AlternatorDynamoDBClientBuilder withTlsConfig(TlsConfig? tlsConfig)
+        {
+            return this.WithTlsConfig(tlsConfig);
+        }
+
+        public AlternatorDynamoDBClientBuilder withTlsSessionCacheConfig(TlsSessionCacheConfig? tlsSessionCacheConfig)
+        {
+            return this.WithTlsSessionCacheConfig(tlsSessionCacheConfig);
+        }
+
+        public AlternatorDynamoDBClientBuilder withActiveRefreshIntervalMs(long intervalMs)
+        {
+            return this.WithActiveRefreshIntervalMs(intervalMs);
+        }
+
+        public AlternatorDynamoDBClientBuilder withIdleRefreshIntervalMs(long intervalMs)
+        {
+            return this.WithIdleRefreshIntervalMs(intervalMs);
+        }
+
+        public AlternatorDynamoDBClientBuilder withMaxConnections(int maxConnections)
+        {
+            return this.WithMaxConnections(maxConnections);
+        }
+
+        public AlternatorDynamoDBClientBuilder withConnectionMaxIdleTimeMs(long connectionMaxIdleTimeMs)
+        {
+            return this.WithConnectionMaxIdleTimeMs(connectionMaxIdleTimeMs);
+        }
+
+        public AlternatorDynamoDBClientBuilder withConnectionTimeToLiveMs(long connectionTimeToLiveMs)
+        {
+            return this.WithConnectionTimeToLiveMs(connectionTimeToLiveMs);
+        }
+
+        public AlternatorDynamoDBClientBuilder withConnectionAcquisitionTimeoutMs(long connectionAcquisitionTimeoutMs)
+        {
+            return this.WithConnectionAcquisitionTimeoutMs(connectionAcquisitionTimeoutMs);
+        }
+
+        public AlternatorDynamoDBClientBuilder withConnectionTimeoutMs(long connectionTimeoutMs)
+        {
+            return this.WithConnectionTimeoutMs(connectionTimeoutMs);
+        }
+
+        public AlternatorDynamoDBClientBuilder withDisableCertificateChecks()
+        {
+            return this.WithDisableCertificateChecks();
+        }
+
+        public AlternatorDynamoDBClientBuilder withHttpClientHandlerCustomizer(Action<HttpClientHandler> customizer)
+        {
+            return this.WithHttpClientHandlerCustomizer(customizer);
+        }
+
+        public AlternatorDynamoDBClientBuilder withSocketsHttpHandlerCustomizer(Action<SocketsHttpHandler> customizer)
+        {
+            return this.WithSocketsHttpHandlerCustomizer(customizer);
+        }
+
+        public AlternatorDynamoDBClientBuilder withApacheHttpClientCustomizer(Action<HttpClientHandler> customizer)
+        {
+            return this.WithApacheHttpClientCustomizer(customizer);
+        }
+
+        public AlternatorDynamoDBClientBuilder withCrtHttpClientCustomizer(Action<HttpClientHandler> customizer)
+        {
+            return this.WithCrtHttpClientCustomizer(customizer);
+        }
+
+        public AlternatorDynamoDBClientBuilder withSystemNetHttpClientCustomizer(Action<HttpClientHandler> customizer)
+        {
+            return this.WithSystemNetHttpClientCustomizer(customizer);
+        }
+
+        public AlternatorDynamoDBClientBuilder withHttpClientType(HttpClientType httpClientType)
+        {
+            return this.WithHttpClientType(httpClientType);
+        }
+
+        public AlternatorDynamoDBClientBuilder withHttpClientType(HttpClientType? httpClientType)
+        {
+            return this.WithHttpClientType(httpClientType);
+        }
+
+        public AmazonDynamoDBConfig overrideConfiguration()
+        {
+            return this.OverrideConfiguration();
+        }
+
+        public AlternatorDynamoDBClientBuilder overrideConfiguration(Action<AmazonDynamoDBConfig> configure)
+        {
+            return this.OverrideConfiguration(configure);
+        }
+
+        public AlternatorDynamoDBClientBuilder overrideConfiguration(AmazonDynamoDBConfig config)
+        {
+            return this.OverrideConfiguration(config);
+        }
+
+        public AlternatorDynamoDBClientBuilder accountIdEndpointMode(AccountIdEndpointMode accountIdEndpointMode)
+        {
+            return this.AccountIdEndpointMode(accountIdEndpointMode);
+        }
+
+        public AlternatorDynamoDBClientBuilder httpClientFactory(HttpClientFactory httpClientFactory)
+        {
+            return this.WithHttpClientFactory(httpClientFactory);
+        }
+
+        public AlternatorDynamoDBClientBuilder httpClient(HttpClientFactory httpClientFactory)
+        {
+            return this.WithHttpClientFactory(httpClientFactory);
+        }
+
+        public AlternatorDynamoDBClientBuilder httpClientBuilder(HttpClientFactory httpClientFactory)
+        {
+            return this.WithHttpClientFactory(httpClientFactory);
+        }
+
+        public AlternatorDynamoDBClientBuilder endpointProvider(IEndpointProvider endpointProvider)
+        {
+            return this.EndpointProvider(endpointProvider);
+        }
+
+        public AlternatorDynamoDBClientBuilder endpointDiscoveryEnabled(bool endpointDiscoveryEnabled)
+        {
+            return this.EndpointDiscoveryEnabled(endpointDiscoveryEnabled);
+        }
+
+        public AlternatorDynamoDBClientBuilder enableEndpointDiscovery()
+        {
+            return this.EnableEndpointDiscovery();
+        }
+
+        public AlternatorDynamoDBClientBuilder fipsEnabled(bool? fipsEnabled)
+        {
+            return this.FipsEnabled(fipsEnabled);
+        }
+
+        public AlternatorDynamoDBClientBuilder dualstackEnabled(bool? dualstackEnabled)
+        {
+            return this.DualstackEnabled(dualstackEnabled);
+        }
+
+        public AmazonDynamoDBClient build()
+        {
+            return this.Build();
+        }
+
+        public AlternatorDynamoDBClientWrapper buildWithAlternatorAPI()
+        {
+            return this.BuildWithAlternatorAPI();
+        }
+#pragma warning restore SA1300, IDE1006
+
+        private static AlternatorConfig CreateConfigWithTlsConfig(AlternatorConfig config, TlsConfig tlsConfig)
+        {
+            return AlternatorConfig.Builder()
+                .WithSeedHosts(config.SeedHosts)
+                .WithScheme(config.Scheme)
+                .WithPort(config.Port)
+                .WithRoutingScope(config.RoutingScope)
+                .WithCompressionAlgorithm(config.CompressionAlgorithm)
+                .WithMinCompressionSizeBytes(config.MinCompressionSizeBytes)
+                .WithOptimizeHeaders(config.OptimizeHeaders)
+                .WithHeadersWhitelist(config.HeadersWhitelist)
+                .WithUserAgentEnabled(config.UserAgentEnabled)
+                .WithAuthenticationEnabled(config.AuthenticationEnabled)
+                .WithTlsConfig(tlsConfig)
+                .WithTlsSessionCacheConfig(config.TlsSessionCacheConfig)
+                .WithKeyRouteAffinity(config.KeyRouteAffinityConfig)
+                .WithActiveRefreshIntervalMs(config.ActiveRefreshIntervalMs)
+                .WithIdleRefreshIntervalMs(config.IdleRefreshIntervalMs)
+                .WithMaxConnections(config.MaxConnections)
+                .WithConnectionMaxIdleTimeMs(config.ConnectionMaxIdleTimeMs)
+                .WithConnectionTimeToLiveMs(config.ConnectionTimeToLiveMs)
+                .WithConnectionAcquisitionTimeoutMs(config.ConnectionAcquisitionTimeoutMs)
+                .WithConnectionTimeoutMs(config.ConnectionTimeoutMs)
+                .Build();
+        }
+
+        private ClientArtifacts BuildClientArtifacts()
+        {
+            this.configBuilder.WithAuthenticationEnabled(this.credentials != null);
+            if (this.disableCertificateChecks)
+            {
+                this.configBuilder.WithTlsConfig(TlsConfig.TrustAll());
+            }
+
+            var alternatorConfig = this.options?.ToAlternatorConfig() ?? this.configBuilder.Build();
+            if (this.disableCertificateChecks && this.options != null)
+            {
+                alternatorConfig = CreateConfigWithTlsConfig(alternatorConfig, TlsConfig.TrustAll());
+            }
+
+            this.ValidateSeedConfiguration(alternatorConfig);
+            var dynamoDbConfig = this.GetOrCreateDynamoDbConfig();
+            this.ValidateHttpClientConfiguration(dynamoDbConfig);
+            var endpointProvider = this.options != null
+                ? new Helper(this.options)
+                : new Helper(alternatorConfig, this.validateOnInitialization, this.startImmediately, this.cancellationToken);
+
+            if (alternatorConfig.ConnectionTimeoutMs > 0)
+            {
+                dynamoDbConfig.Timeout = TimeSpan.FromMilliseconds(alternatorConfig.ConnectionTimeoutMs);
+            }
+
+            dynamoDbConfig.MaxConnectionsPerServer = alternatorConfig.MaxConnections;
+            dynamoDbConfig.HttpClientFactory ??= new AlternatorHttpClientFactory(
+                alternatorConfig,
+                this.configureHttpClientHandler,
+                this.configureSocketsHttpHandler);
+            this.configureAws?.Invoke(dynamoDbConfig);
+            dynamoDbConfig.EndpointProvider = endpointProvider;
+            var partitionKeyResolver = alternatorConfig.KeyRouteAffinityConfig?.IsEnabled == true
+                ? new PartitionKeyResolver(alternatorConfig.KeyRouteAffinityConfig.PkInfoPerTable.ToDictionary(item => item.Key, item => item.Value))
+                : null;
+            var client = AlternatorAmazonDynamoDBClient.Create(
+                this.credentials ?? new AnonymousAWSCredentials(),
+                dynamoDbConfig,
+                alternatorConfig,
+                endpointProvider,
+                partitionKeyResolver,
+                this.userAgentTransformer,
+                this.defaultUserAgentTokenEnabled && alternatorConfig.UserAgentEnabled);
+            partitionKeyResolver?.SetClientForDiscovery(client);
+            return new ClientArtifacts(client, endpointProvider, alternatorConfig, partitionKeyResolver);
+        }
+
+        private AmazonDynamoDBConfig GetOrCreateDynamoDbConfig()
+        {
+            this.config ??= new AmazonDynamoDBConfig
+            {
+                RegionEndpoint = Amazon.RegionEndpoint.USEast1,
+            };
+            return this.config;
+        }
+
+        private void ValidateSeedConfiguration(AlternatorConfig alternatorConfig)
+        {
+            if (alternatorConfig.SeedHosts.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    "endpointOverride must be set when using AlternatorDynamoDBClientBuilder. Call endpointOverride(Uri) with the seed Alternator node URI.");
+            }
+        }
+
+        private void ValidateHttpClientConfiguration(AmazonDynamoDBConfig dynamoDbConfig)
+        {
+            var hasCustomHttpClientFactory = this.httpClientFactorySet
+                || (dynamoDbConfig.HttpClientFactory != null
+                    && dynamoDbConfig.HttpClientFactory.GetType() != typeof(AlternatorHttpClientFactory));
+
+            if (hasCustomHttpClientFactory
+                && (this.configureHttpClientHandler != null || this.configureSocketsHttpHandler != null))
+            {
+                throw new InvalidOperationException(
+                    "Cannot use httpClient()/httpClientFactory() together with HTTP handler customizers. Use one transport configuration approach.");
+            }
+
+            if (hasCustomHttpClientFactory && this.httpClientTypeSet)
+            {
+                throw new InvalidOperationException(
+                    "Cannot use httpClient()/httpClientFactory() together with withHttpClientType(). Use one transport configuration approach.");
+            }
+
+            if (this.configureHttpClientHandler != null && this.configureSocketsHttpHandler != null)
+            {
+                throw new InvalidOperationException(
+                    "HttpClientHandler and SocketsHttpHandler customizers cannot be used together.");
+            }
+
+            if (this.apacheHttpClientCustomizerSet && this.crtHttpClientCustomizerSet)
+            {
+                throw new InvalidOperationException(
+                    "Cannot use Apache and CRT HTTP client customizers together. Use one HTTP client customizer.");
+            }
+
+            if (this.apacheHttpClientCustomizerSet && this.systemNetHttpClientCustomizerSet)
+            {
+                throw new InvalidOperationException(
+                    "Cannot use Apache and System.Net HTTP client customizers together. Use one HTTP client customizer.");
+            }
+
+            if (this.crtHttpClientCustomizerSet && this.systemNetHttpClientCustomizerSet)
+            {
+                throw new InvalidOperationException(
+                    "Cannot use CRT and System.Net HTTP client customizers together. Use one HTTP client customizer.");
+            }
+
+            if (this.httpClientType == HttpClientType.Netty)
+            {
+                throw new NotSupportedException(
+                    "HttpClientType.NETTY does not apply to the synchronous AmazonDynamoDBClient. Use HttpClientType.SYSTEM_NET_HTTP, APACHE, CRT, or AUTO.");
+            }
+
+            if (this.httpClientType == HttpClientType.Apache
+                && (this.crtHttpClientCustomizerSet || this.systemNetHttpClientCustomizerSet))
+            {
+                throw new InvalidOperationException(
+                    "HttpClientType.APACHE cannot be used with CRT or System.Net HTTP client customizers.");
+            }
+
+            if (this.httpClientType == HttpClientType.Crt
+                && (this.apacheHttpClientCustomizerSet || this.systemNetHttpClientCustomizerSet))
+            {
+                throw new InvalidOperationException(
+                    "HttpClientType.CRT cannot be used with Apache or System.Net HTTP client customizers.");
+            }
+
+            if (this.httpClientType == HttpClientType.SystemNetHttp
+                && (this.apacheHttpClientCustomizerSet || this.crtHttpClientCustomizerSet))
+            {
+                throw new InvalidOperationException(
+                    "HttpClientType.SYSTEM_NET_HTTP cannot be used with Apache or CRT HTTP client customizers.");
+            }
+        }
+
+        private void ApplyAlternatorConfig(AlternatorConfig config)
+        {
+            this.configBuilder
+                .WithRoutingScope(config.RoutingScope)
+                .WithCompressionAlgorithm(config.CompressionAlgorithm)
+                .WithMinCompressionSizeBytes(config.MinCompressionSizeBytes)
+                .WithOptimizeHeaders(config.OptimizeHeaders)
+                .WithHeadersWhitelist(config.HeadersWhitelist)
+                .WithUserAgentEnabled(config.UserAgentEnabled)
+                .WithAuthenticationEnabled(config.AuthenticationEnabled)
+                .WithTlsConfig(config.TlsConfig)
+                .WithTlsSessionCacheConfig(config.TlsSessionCacheConfig)
+                .WithKeyRouteAffinity(config.KeyRouteAffinityConfig)
+                .WithActiveRefreshIntervalMs(config.ActiveRefreshIntervalMs)
+                .WithIdleRefreshIntervalMs(config.IdleRefreshIntervalMs)
+                .WithMaxConnections(config.MaxConnections)
+                .WithConnectionMaxIdleTimeMs(config.ConnectionMaxIdleTimeMs)
+                .WithConnectionTimeToLiveMs(config.ConnectionTimeToLiveMs)
+                .WithConnectionAcquisitionTimeoutMs(config.ConnectionAcquisitionTimeoutMs)
+                .WithConnectionTimeoutMs(config.ConnectionTimeoutMs);
+        }
+
+        private void ApplyLegacyRoutingScope()
+        {
+            RoutingScope? routingScope = null;
+            if (!string.IsNullOrEmpty(this.datacenter) && !string.IsNullOrEmpty(this.rack))
+            {
+                routingScope = RackScope.Of(
+                    this.datacenter,
+                    this.rack,
+                    DatacenterScope.Of(this.datacenter, ClusterScope.Create()));
+            }
+            else if (!string.IsNullOrEmpty(this.datacenter))
+            {
+                routingScope = DatacenterScope.Of(this.datacenter, ClusterScope.Create());
+            }
+
+            this.configBuilder.WithRoutingScope(routingScope);
+        }
+
+        private sealed class ClientArtifacts
+        {
+            internal ClientArtifacts(
+                AmazonDynamoDBClient client,
+                Helper endpointProvider,
+                AlternatorConfig alternatorConfig,
+                PartitionKeyResolver? partitionKeyResolver)
+            {
+                this.Client = client;
+                this.EndpointProvider = endpointProvider;
+                this.AlternatorConfig = alternatorConfig;
+                this.PartitionKeyResolver = partitionKeyResolver;
+            }
+
+            internal AmazonDynamoDBClient Client { get; }
+
+            internal Helper EndpointProvider { get; }
+
+            internal AlternatorConfig AlternatorConfig { get; }
+
+            internal PartitionKeyResolver? PartitionKeyResolver { get; }
+        }
+    }
+}

--- a/AlternatorDynamoDBClientWrapper.cs
+++ b/AlternatorDynamoDBClientWrapper.cs
@@ -1,0 +1,144 @@
+// <copyright file="AlternatorDynamoDBClientWrapper.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    using Amazon.DynamoDBv2;
+    using ScyllaDB.Alternator.KeyRouting;
+
+    public sealed class AlternatorDynamoDBClientWrapper : IDisposable
+    {
+        private readonly AlternatorConfig? config;
+        private readonly AlternatorLiveNodes liveNodes;
+        private readonly PartitionKeyResolver? partitionKeyResolver;
+
+        public AlternatorDynamoDBClientWrapper(AmazonDynamoDBClient client, AlternatorLiveNodes liveNodes)
+            : this(client, liveNodes, null, null)
+        {
+        }
+
+        public AlternatorDynamoDBClientWrapper(AmazonDynamoDBClient client, AlternatorLiveNodes liveNodes, AlternatorConfig? config)
+            : this(client, liveNodes, config, null)
+        {
+        }
+
+        public AlternatorDynamoDBClientWrapper(
+            AmazonDynamoDBClient client,
+            AlternatorLiveNodes liveNodes,
+            AlternatorConfig? config,
+            PartitionKeyResolver? partitionKeyResolver)
+        {
+            this.Client = client ?? throw new ArgumentNullException(nameof(client));
+            this.liveNodes = liveNodes ?? throw new ArgumentNullException(nameof(liveNodes));
+            this.config = config;
+            this.partitionKeyResolver = partitionKeyResolver;
+            this.partitionKeyResolver?.SetClientForDiscovery(client);
+        }
+
+        internal AlternatorDynamoDBClientWrapper(
+            AmazonDynamoDBClient client,
+            Helper endpointProvider,
+            AlternatorConfig config,
+            PartitionKeyResolver? partitionKeyResolver)
+            : this(client, RequireLiveNodes(endpointProvider), config, partitionKeyResolver)
+        {
+        }
+
+        public AmazonDynamoDBClient Client { get; }
+
+        public AlternatorConfig Config => this.config
+            ?? throw new InvalidOperationException("AlternatorConfig is not available for this wrapper.");
+
+        public PartitionKeyResolver? PartitionKeyResolver => this.partitionKeyResolver;
+
+        public AmazonDynamoDBClient GetClient()
+        {
+            return this.Client;
+        }
+
+        public IReadOnlyList<Uri> GetLiveNodes()
+        {
+            return this.liveNodes.GetLiveNodes();
+        }
+
+        public Uri NextAsURI()
+        {
+            return this.liveNodes.NextAsUri();
+        }
+
+        public bool CheckIfRackDatacenterFeatureIsSupported()
+        {
+            return this.liveNodes.CheckIfRackDatacenterFeatureIsSupported();
+        }
+
+        public AlternatorConfig? GetAlternatorConfig()
+        {
+            return this.config;
+        }
+
+        public AlternatorLiveNodes GetAlternatorLiveNodes()
+        {
+            return this.liveNodes;
+        }
+
+        public void Close()
+        {
+            this.Dispose();
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public AmazonDynamoDBClient getClient()
+        {
+            return this.GetClient();
+        }
+
+        public IReadOnlyList<Uri> getLiveNodes()
+        {
+            return this.GetLiveNodes();
+        }
+
+        public Uri nextAsURI()
+        {
+            return this.NextAsURI();
+        }
+
+        public bool checkIfRackDatacenterFeatureIsSupported()
+        {
+            return this.CheckIfRackDatacenterFeatureIsSupported();
+        }
+
+        public AlternatorConfig? getAlternatorConfig()
+        {
+            return this.GetAlternatorConfig();
+        }
+
+        public AlternatorLiveNodes getAlternatorLiveNodes()
+        {
+            return this.GetAlternatorLiveNodes();
+        }
+
+        public void close()
+        {
+            this.Close();
+        }
+#pragma warning restore SA1300, IDE1006
+
+        public void Dispose()
+        {
+            this.partitionKeyResolver?.Dispose();
+            this.liveNodes.ShutdownAndWait();
+            this.Client.Dispose();
+        }
+
+        private static AlternatorLiveNodes RequireLiveNodes(Helper endpointProvider)
+        {
+            if (endpointProvider == null)
+            {
+                throw new ArgumentNullException(nameof(endpointProvider));
+            }
+
+            return endpointProvider.GetAlternatorLiveNodes();
+        }
+    }
+}

--- a/UnitTests/ClientBuilderUnitTests.cs
+++ b/UnitTests/ClientBuilderUnitTests.cs
@@ -1,0 +1,610 @@
+// <copyright file="ClientBuilderUnitTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    using Amazon;
+    using Amazon.DynamoDBv2;
+    using Amazon.DynamoDBv2.Model;
+    using Amazon.Runtime;
+    using ScyllaDB.Alternator.KeyRouting;
+    using ScyllaDB.Alternator.Routing;
+
+    [TestFixture]
+    [Category("Unit")]
+    public class ClientBuilderUnitTests
+    {
+        [Test]
+        public void AlternatorDynamoDBClientBuilderFactoryTest()
+        {
+            var builder = AlternatorDynamoDBClient.builder();
+
+            Assert.That(builder, Is.Not.Null);
+            Assert.That(builder, Is.InstanceOf<AlternatorDynamoDBClientBuilder>());
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderBuildsClientTest()
+        {
+            var credentials = new BasicAWSCredentials("user", "password");
+
+            using var client = AlternatorDynamoDBClient.Builder()
+                .WithCredentials(credentials)
+                .WithInitialNodeUri(new Uri("http://127.0.0.1:8080"))
+                .WithDatacenterAndRack("dc1", "rack1")
+                .WithoutValidation()
+                .WithDeferredStart()
+                .Build();
+
+            Assert.That(client, Is.Not.Null);
+            Assert.That(client, Is.InstanceOf<AmazonDynamoDBClient>());
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderJavaStyleBuildReturnsAwsDynamoDbClientTest()
+        {
+            using var client = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .WithoutValidation()
+                .WithDeferredStart()
+                .build();
+
+            Assert.That(client, Is.InstanceOf<AmazonDynamoDBClient>());
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderSupportsJavaStyleEndpointOverrideTest()
+        {
+            using var client = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .WithRoutingScope(DatacenterScope.of("dc1", ClusterScope.create()))
+                .WithoutValidation()
+                .WithDeferredStart()
+                .Build();
+
+            Assert.That(client, Is.Not.Null);
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderBuildsWrapperWithAlternatorApiTest()
+        {
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+
+            Assert.That(wrapper, Is.Not.Null);
+            Assert.That(wrapper.getClient(), Is.InstanceOf<AmazonDynamoDBClient>());
+            Assert.That(wrapper.getLiveNodes(), Is.EqualTo(new List<Uri> { new Uri("http://127.0.0.1:8080") }));
+            Assert.That(wrapper.nextAsURI(), Is.EqualTo(new Uri("http://127.0.0.1:8080")));
+            Assert.That(wrapper.getAlternatorLiveNodes(), Is.SameAs(wrapper.GetAlternatorLiveNodes()));
+            Assert.That(wrapper.getAlternatorLiveNodes().getLiveNodes(), Is.EqualTo(new List<Uri> { new Uri("http://127.0.0.1:8080") }));
+            Assert.That(wrapper.getAlternatorLiveNodes().nextAsURI("/localnodes", "rack=r1"), Is.EqualTo(new Uri("http://127.0.0.1:8080/localnodes?rack=r1")));
+            Assert.DoesNotThrow(() => wrapper.Close());
+            Assert.DoesNotThrow(() => wrapper.close());
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderRequiresEndpointOverrideTest()
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                AlternatorDynamoDBClient.builder()
+                    .WithoutValidation()
+                    .WithDeferredStart()
+                    .build());
+
+            Assert.That(exception!.Message, Does.Contain("endpointOverride must be set"));
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientWrapperSupportsJavaStyleConstructorsTest()
+        {
+            var config = AlternatorConfig.builder()
+                .withSeedNode("http://127.0.0.1:8080")
+                .build();
+            var clientConfig = new AmazonDynamoDBConfig
+            {
+                RegionEndpoint = RegionEndpoint.USEast1,
+                ServiceURL = "http://127.0.0.1:8080",
+            };
+            var client = new AmazonDynamoDBClient(new AnonymousAWSCredentials(), clientConfig);
+            var liveNodes = new AlternatorLiveNodes(config);
+            using var wrapper = new AlternatorDynamoDBClientWrapper(client, liveNodes);
+
+            Assert.That(wrapper.getClient(), Is.SameAs(client));
+            Assert.That(wrapper.getAlternatorLiveNodes(), Is.SameAs(liveNodes));
+            Assert.That(wrapper.getAlternatorConfig(), Is.Null);
+            Assert.Throws<InvalidOperationException>(() => _ = wrapper.Config);
+
+            var clientWithConfig = new AmazonDynamoDBClient(new AnonymousAWSCredentials(), clientConfig);
+            var liveNodesWithConfig = new AlternatorLiveNodes(config);
+            using var wrapperWithConfig = new AlternatorDynamoDBClientWrapper(clientWithConfig, liveNodesWithConfig, config);
+
+            Assert.That(wrapperWithConfig.getClient(), Is.SameAs(clientWithConfig));
+            Assert.That(wrapperWithConfig.getAlternatorLiveNodes(), Is.SameAs(liveNodesWithConfig));
+            Assert.That(wrapperWithConfig.getAlternatorConfig(), Is.SameAs(config));
+            Assert.That(wrapperWithConfig.Config, Is.SameAs(config));
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientWrapperCloseWaitsForLiveNodesShutdownTest()
+        {
+            var handler = new TrackingHttpMessageHandler();
+            using var pollingHttpClient = new HttpClient(handler);
+            var config = AlternatorConfig.builder()
+                .withSeedHost("127.0.0.1")
+                .withScheme("http")
+                .withPort(8080)
+                .withRoutingScope(ClusterScope.create())
+                .build();
+            var clientConfig = new AmazonDynamoDBConfig
+            {
+                RegionEndpoint = RegionEndpoint.USEast1,
+                ServiceURL = "http://127.0.0.1:8080",
+            };
+            var client = new AmazonDynamoDBClient(new AnonymousAWSCredentials(), clientConfig);
+            var liveNodes = new AlternatorLiveNodes(config, pollingHttpClient);
+            var wrapper = new AlternatorDynamoDBClientWrapper(client, liveNodes, config);
+
+            liveNodes.start().Wait(TimeSpan.FromSeconds(5));
+            Assert.That(
+                SpinWait.SpinUntil(() => handler.SendCount > 0, TimeSpan.FromSeconds(5)),
+                Is.True);
+
+            wrapper.close();
+
+            Assert.That(liveNodes.isRunning(), Is.False);
+            Assert.That(handler.DisposeCount, Is.EqualTo(0));
+            Assert.That(handler.SendCount, Is.GreaterThanOrEqualTo(1));
+        }
+
+        [Test]
+        public async Task AlternatorLiveNodesShutdownStopsCanceledStartTest()
+        {
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+            var liveNodes = wrapper.getAlternatorLiveNodes();
+
+            await liveNodes.Start(cancellation.Token);
+            await WaitUntilAsync(() => !liveNodes.IsRunning());
+            liveNodes.shutdown();
+
+            Assert.That(liveNodes.isRunning(), Is.False);
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderSupportsJavaStyleBuildAndConfigCopyTest()
+        {
+            var config = AlternatorConfig.builder()
+                .withSeedNode("http://127.0.0.1:8080")
+                .withCompressionAlgorithm(RequestCompressionAlgorithm.NONE)
+                .withMaxConnections(50)
+                .build();
+
+            using var client = AlternatorDynamoDBClient.builder()
+                .withAlternatorConfig(null)
+                .endpointOverride("http://127.0.0.1:8080")
+                .WithoutValidation()
+                .WithDeferredStart()
+                .build();
+
+            var noEndpointBuilder = AlternatorDynamoDBClient.builder()
+                .withAlternatorConfig(config)
+                .WithoutValidation()
+                .WithDeferredStart();
+            Assert.Throws<InvalidOperationException>(() => noEndpointBuilder.buildWithAlternatorAPI());
+
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .withAlternatorConfig(config)
+                .endpointOverride("http://127.0.0.1:8080")
+                .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+                .withCompressionAlgorithm(null)
+                .withMaxConnections(75)
+                .region(RegionEndpoint.USWest2)
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+
+            Assert.That(client, Is.InstanceOf<AmazonDynamoDBClient>());
+            Assert.That(wrapper.Config.getSeedHosts(), Is.EqualTo(new[] { "127.0.0.1" }));
+            Assert.That(wrapper.Config.getScheme(), Is.EqualTo("http"));
+            Assert.That(wrapper.Config.getPort(), Is.EqualTo(8080));
+            Assert.That(wrapper.Config.getCompressionAlgorithm(), Is.EqualTo(RequestCompressionAlgorithm.None));
+            Assert.That(wrapper.Config.getMaxConnections(), Is.EqualTo(75));
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderCopiesAlternatorConfigHeadersWhitelistLikeJavaTest()
+        {
+            var config = AlternatorConfig.builder()
+                .withSeedNode("http://127.0.0.1:8080")
+                .withCompressionAlgorithm(RequestCompressionAlgorithm.NONE)
+                .build();
+
+            var builder = AlternatorDynamoDBClient.builder()
+                .withAlternatorConfig(config)
+                .endpointOverride("http://127.0.0.1:8080")
+                .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+                .WithoutValidation()
+                .WithDeferredStart();
+
+            var exception = Assert.Throws<ArgumentException>(() => builder.buildWithAlternatorAPI());
+            Assert.That(exception!.Message, Does.Contain("Content-Encoding"));
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderDisableCertificateChecksWinsAtBuildLikeJavaTest()
+        {
+            var strictTlsConfig = TlsConfig.systemDefault();
+            var config = AlternatorConfig.builder()
+                .withSeedNode("https://127.0.0.1:8181")
+                .withTlsConfig(strictTlsConfig)
+                .build();
+
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .withDisableCertificateChecks()
+                .withAlternatorConfig(config)
+                .endpointOverride("https://127.0.0.1:8181")
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+
+            Assert.That(wrapper.Config.getTlsConfig().isTrustAllCertificates(), Is.True);
+            Assert.That(wrapper.Config.getTlsConfig().isVerifyHostname(), Is.False);
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderSupportsAwsBuilderParityMethodsTest()
+        {
+            var builder = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .WithoutValidation()
+                .WithDeferredStart();
+
+            Assert.That(builder.region("us-west-2"), Is.SameAs(builder));
+            Assert.That(builder.overrideConfiguration().RegionEndpoint, Is.EqualTo(RegionEndpoint.USWest2));
+            Assert.That(builder.region(RegionEndpoint.USEast1), Is.SameAs(builder));
+            Assert.That(builder.overrideConfiguration().RegionEndpoint, Is.EqualTo(RegionEndpoint.USEast1));
+            Assert.That(builder.overrideConfiguration(config => config.Timeout = TimeSpan.FromSeconds(3)), Is.SameAs(builder));
+            Assert.That(builder.overrideConfiguration().Timeout, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            var replacementConfig = new AmazonDynamoDBConfig
+            {
+                RegionEndpoint = RegionEndpoint.USWest2,
+                Timeout = TimeSpan.FromSeconds(4),
+            };
+            Assert.That(builder.overrideConfiguration(replacementConfig), Is.SameAs(builder));
+            Assert.That(builder.overrideConfiguration(), Is.SameAs(replacementConfig));
+            Assert.That(builder.accountIdEndpointMode(AccountIdEndpointMode.DISABLED), Is.SameAs(builder));
+            Assert.Throws<NotSupportedException>(() => builder.endpointProvider(null!));
+            Assert.Throws<NotSupportedException>(() => builder.endpointDiscoveryEnabled(true));
+            Assert.Throws<NotSupportedException>(() => builder.enableEndpointDiscovery());
+            Assert.Throws<NotSupportedException>(() => builder.fipsEnabled(true));
+            Assert.Throws<NotSupportedException>(() => builder.dualstackEnabled(true));
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderSupportsCredentialConvenienceOverloadsTest()
+        {
+            using var basicWrapper = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .credentialsProvider("access-key", "secret-key")
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+            using var sessionWrapper = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8081")
+                .credentialsProvider("access-key", "secret-key", "session-token")
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+
+            Assert.That(basicWrapper.Config.isAuthenticationEnabled(), Is.True);
+            Assert.That(sessionWrapper.Config.isAuthenticationEnabled(), Is.True);
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderSupportsHttpClientHandlerCustomizerTest()
+        {
+            var builder = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080");
+
+            Assert.That(builder.withHttpClientHandlerCustomizer(_ => { }), Is.SameAs(builder));
+            Assert.That(builder.withApacheHttpClientCustomizer(_ => { }), Is.SameAs(builder));
+            Assert.That(builder.withCrtHttpClientCustomizer(_ => { }), Is.SameAs(builder));
+            Assert.That(builder.withSystemNetHttpClientCustomizer(_ => { }), Is.SameAs(builder));
+            Assert.That(builder.withHttpClientType(HttpClientType.APACHE), Is.SameAs(builder));
+            Assert.That(builder.HttpClientType, Is.EqualTo(HttpClientType.Apache));
+            Assert.That(builder.withHttpClientType(HttpClientType.CRT), Is.SameAs(builder));
+            Assert.That(builder.HttpClientType, Is.EqualTo(HttpClientType.Crt));
+            Assert.Throws<ArgumentNullException>(() => builder.withHttpClientType(null));
+            Assert.Throws<ArgumentNullException>(() => builder.withHttpClientHandlerCustomizer(null!));
+            Assert.Throws<ArgumentNullException>(() => builder.withApacheHttpClientCustomizer(null!));
+            Assert.Throws<ArgumentNullException>(() => builder.withCrtHttpClientCustomizer(null!));
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderSupportsHttpClientFactoryTest()
+        {
+            var factory = new TestHttpClientFactory();
+            var builder = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .WithoutValidation()
+                .WithDeferredStart();
+
+            Assert.That(builder.httpClientFactory(factory), Is.SameAs(builder));
+            Assert.That(builder.overrideConfiguration().HttpClientFactory, Is.SameAs(factory));
+
+            using var client = builder.build();
+            Assert.That(client, Is.Not.Null);
+            Assert.Throws<ArgumentNullException>(() => AlternatorDynamoDBClient.builder().httpClientFactory(null!));
+            Assert.Throws<InvalidOperationException>(() => AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .httpClient(factory)
+                .withHttpClientType(HttpClientType.APACHE)
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI());
+            Assert.Throws<InvalidOperationException>(() => AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .httpClientBuilder(factory)
+                .withSocketsHttpHandlerCustomizer(_ => { })
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI());
+            Assert.Throws<NotSupportedException>(() => AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .withHttpClientType(HttpClientType.NETTY)
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI());
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderValidatesJavaStyleHttpClientCustomizerConflictsTest()
+        {
+            Assert.Throws<InvalidOperationException>(() => AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .withApacheHttpClientCustomizer(_ => { })
+                .withCrtHttpClientCustomizer(_ => { })
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI());
+
+            Assert.Throws<InvalidOperationException>(() => AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .withHttpClientType(HttpClientType.APACHE)
+                .withCrtHttpClientCustomizer(_ => { })
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI());
+
+            Assert.Throws<InvalidOperationException>(() => AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .withHttpClientType(HttpClientType.CRT)
+                .withApacheHttpClientCustomizer(_ => { })
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI());
+
+            using var apacheWrapper = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .withHttpClientType(HttpClientType.APACHE)
+                .withApacheHttpClientCustomizer(_ => { })
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+            using var crtWrapper = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8081")
+                .withHttpClientType(HttpClientType.CRT)
+                .withCrtHttpClientCustomizer(_ => { })
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+
+            Assert.That(apacheWrapper.Config, Is.Not.Null);
+            Assert.That(crtWrapper.Config, Is.Not.Null);
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderSupportsSocketsHttpHandlerCustomizerTest()
+        {
+            var builder = AlternatorDynamoDBClient.builder()
+                .endpointOverride("https://127.0.0.1:8181");
+
+            Assert.That(builder.withSocketsHttpHandlerCustomizer(_ => { }), Is.SameAs(builder));
+            Assert.Throws<ArgumentNullException>(() => builder.withSocketsHttpHandlerCustomizer(null!));
+
+            using var wrapper = builder
+                .withAlternatorConfig(AlternatorConfig.builder()
+                    .withSeedNode("https://127.0.0.1:8181")
+                    .withMaxConnections(321)
+                    .withConnectionMaxIdleTimeMs(30000)
+                    .withConnectionTimeToLiveMs(60000)
+                    .withConnectionTimeoutMs(7000)
+                    .withTlsConfig(TlsConfig.trustAll())
+                    .build())
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+
+            Assert.That(wrapper.Config.getMaxConnections(), Is.EqualTo(321));
+            Assert.That(wrapper.Config.getConnectionMaxIdleTimeMs(), Is.EqualTo(30000));
+            Assert.That(wrapper.Config.getConnectionTimeToLiveMs(), Is.EqualTo(60000));
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderSupportsCompressionAndHeaderOptimizationTest()
+        {
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+                .withMinCompressionSizeBytes(1)
+                .withOptimizeHeaders(true)
+                .withHeadersWhitelist(new[]
+                {
+                    "Host",
+                    "X-Amz-Target",
+                    "Content-Type",
+                    "Content-Length",
+                    "Accept-Encoding",
+                    "Connection",
+                    "User-Agent",
+                    "Content-Encoding",
+                })
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+
+            Assert.That(wrapper.Config.CompressionAlgorithm, Is.EqualTo(RequestCompressionAlgorithm.Gzip));
+            Assert.That(wrapper.Config.MinCompressionSizeBytes, Is.EqualTo(1));
+            Assert.That(wrapper.Config.OptimizeHeaders, Is.True);
+            Assert.That(wrapper.Config.AuthenticationEnabled, Is.False);
+            Assert.That(wrapper.Config.HeadersWhitelist, Does.Contain("Content-Encoding"));
+            Assert.That(wrapper.Config.HeadersWhitelist, Does.Not.Contain("Authorization"));
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderSupportsUserAgentConfigurationTest()
+        {
+            var builder = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080");
+
+            Assert.That(builder.withUserAgent("custom/1"), Is.SameAs(builder));
+            Assert.That(builder.withUserAgent(userAgent => userAgent + " app/1"), Is.SameAs(builder));
+            Assert.That(builder.withoutUserAgent(), Is.SameAs(builder));
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderRejectsInvalidUserAgentConfigurationTest()
+        {
+            var builder = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080");
+
+            Assert.Throws<ArgumentException>(() => builder.withUserAgent((string)null!));
+            Assert.Throws<ArgumentException>(() => builder.withUserAgent(" "));
+            var nullTransformer = Assert.Throws<ArgumentException>(() =>
+                builder.withUserAgent((Func<string, string?>)null!));
+            Assert.That(nullTransformer!.Message, Does.Contain("userAgentTransformer cannot be null"));
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderWithoutUserAgentUpdatesHeaderRequirementsTest()
+        {
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .withOptimizeHeaders(true)
+                .withoutUserAgent()
+                .withHeadersWhitelist(AlternatorConfig.BaseRequiredHeaders)
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+
+            Assert.That(wrapper.Config.UserAgentEnabled, Is.False);
+            Assert.That(wrapper.Config.RequiredHeaders, Does.Not.Contain("User-Agent"));
+            Assert.That(wrapper.Config.HeadersWhitelist, Does.Not.Contain("User-Agent"));
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderValidatesAuthenticationHeadersTest()
+        {
+            var credentials = new BasicAWSCredentials("user", "password");
+            var builder = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .credentialsProvider(credentials)
+                .withOptimizeHeaders(true)
+                .withHeadersWhitelist(AlternatorConfig.BaseRequiredHeaders)
+                .WithoutValidation()
+                .WithDeferredStart();
+
+            Assert.Throws<ArgumentException>(() => builder.buildWithAlternatorAPI());
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderSupportsKeyRouteAffinityTest()
+        {
+            var affinity = KeyRouteAffinityConfig.builder()
+                .withType(KeyRouteAffinity.ANY_WRITE)
+                .withPkInfo("users", "user_id")
+                .build();
+
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .withKeyRouteAffinity(affinity)
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+
+            Assert.That(wrapper.Config.KeyRouteAffinityConfig, Is.Not.Null);
+            Assert.That(wrapper.Config.KeyRouteAffinityConfig!.Type, Is.EqualTo(KeyRouteAffinity.AnyWrite));
+            Assert.That(wrapper.Config.KeyRouteAffinityConfig.PkInfoPerTable["users"], Is.EqualTo("user_id"));
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderCreatesPartitionKeyResolverForAffinityAutodiscoveryTest()
+        {
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .withKeyRouteAffinity(KeyRouteAffinity.ANY_WRITE)
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+
+            Assert.That(wrapper.PartitionKeyResolver, Is.Not.Null);
+            Assert.That(wrapper.getAlternatorConfig(), Is.SameAs(wrapper.Config));
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> condition)
+        {
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            while (!condition())
+            {
+                cancellation.Token.ThrowIfCancellationRequested();
+                await Task.Delay(20, cancellation.Token);
+            }
+        }
+
+        private sealed class TrackingHttpMessageHandler : HttpMessageHandler
+        {
+            private int disposeCount;
+            private int sendCount;
+
+            internal int DisposeCount => this.disposeCount;
+
+            internal int SendCount => this.sendCount;
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Interlocked.Increment(ref this.sendCount);
+                return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[\"127.0.0.2\"]", System.Text.Encoding.UTF8, "application/json"),
+                });
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    Interlocked.Increment(ref this.disposeCount);
+                }
+
+                base.Dispose(disposing);
+            }
+        }
+
+        private sealed class TestHttpClientFactory : HttpClientFactory
+        {
+            public override HttpClient CreateHttpClient(IClientConfig clientConfig)
+            {
+                return new HttpClient(new HttpClientHandler());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add the public AlternatorDynamoDBClient factory with Builder() and builder() entry points
- add AlternatorDynamoDBClientBuilder that builds AmazonDynamoDBClient while wiring live-node routing, compression, user agent, TLS, header optimization, and key affinity
- add the wrapper API for Java-style access to the client, live nodes, config, and partition-key resolver
- add focused unit coverage for builder parity, wrapper behavior, credentials, endpoint override, HTTP customizers, and feature toggles

## Verification
- dotnet restore ScyllaDB.Alternator.sln --verbosity minimal
- make build
- make check
- make test-unit