### PR TITLE
Add docs packaging and release automation

### DIFF
--- a/.github/workflows/call_jira_sync.yml
+++ b/.github/workflows/call_jira_sync.yml
@@ -1,0 +1,41 @@
+name: Sync Jira Based on PR Events
+
+on:
+  pull_request_target:
+    types: [opened, edited, ready_for_review, review_requested, labeled, unlabeled, closed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  jira-sync-pr-opened:
+    if: github.event.action == 'opened' || github.event.action == 'edited'
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_opened.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main
+    secrets:
+      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
+
+  jira-sync-in-review:
+    if: github.event.action == 'ready_for_review' || github.event.action == 'review_requested'
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_in_review.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main
+    secrets:
+      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
+
+  jira-sync-add-label:
+    if: github.event.action == 'labeled'
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_add_label.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main
+    secrets:
+      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
+
+  jira-sync-remove-label:
+    if: github.event.action == 'unlabeled'
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_remove_label.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main
+    secrets:
+      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
+
+  jira-sync-pr-closed:
+    if: github.event.action == 'closed'
+    uses: scylladb/github-automation/.github/workflows/main_jira_sync_pr_closed.yml@83115dc2553dbf968e73271e97fc7aac16b8145a # main
+    secrets:
+      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,18 +5,22 @@ on:
     branches:
       - main
     paths-ignore:
+      - .github/workflows/call_jira_sync.yml
+      - .github/workflows/release.yml
       - README.md
 
   pull_request:
     paths-ignore:
+      - .github/workflows/call_jira_sync.yml
+      - .github/workflows/release.yml
       - README.md
 
 env:
   IS_CICD: 1
 
 jobs:
-  build-and-test:
-    name: Build and Test
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
 
     steps:
@@ -26,14 +30,77 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      - name: Check formatting
+        run: make check
+
+  build-and-test:
+    name: Build and Test (.NET ${{ matrix.dotnet-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: [8.0.x]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
       - name: Restore
         run: dotnet restore ScyllaDB.Alternator.sln --verbosity minimal
 
       - name: Build
         run: make build
 
-      - name: Check formatting
-        run: make check
+      - name: Pack and try installing NuGet package
+        run: make try-get
+
+      - name: Upload NuGet package
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-package-dotnet-${{ matrix.dotnet-version }}
+          path: nupkgs/*.nupkg
 
       - name: Run unit tests
         run: make test-unit
+
+      - name: Upload unit test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: unit-test-results-dotnet-${{ matrix.dotnet-version }}
+          path: UnitTests/TestResults/**/*.trx
+
+      - name: Cache Docker image
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: .docker-cache
+          key: scylla-docker-${{ hashFiles('IntegrationTests/docker-compose.yml') }}
+
+      - name: Save Docker image to cache
+        if: steps.docker-cache.outputs.cache-hit != 'true'
+        run: make docker-cache-save
+
+      - name: Cache certificates
+        id: cert-cache
+        uses: actions/cache@v4
+        with:
+          path: .cert-cache
+          key: scylla-certs-${{ hashFiles('Makefile') }}
+
+      - name: Save certificates to cache
+        if: steps.cert-cache.outputs.cache-hit != 'true'
+        run: make cert-cache-save
+
+      - name: Run integration tests
+        run: make test-integration
+
+      - name: Upload integration test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: integration-test-results-dotnet-${{ matrix.dotnet-version }}
+          path: IntegrationTests/TestResults/**/*.trx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        type: boolean
+        description: 'dry-run: build package without pushing to NuGet'
+        default: false
+
+      skip-tests:
+        type: boolean
+        description: 'skip-tests: do not run tests while releasing'
+        default: false
+
+      target-tag:
+        type: string
+        description: 'target-tag: tag or branch name to release. Use to re-release tagged releases'
+        default: main
+
+      release-version:
+        required: false
+        type: string
+        description: 'release-version: override package version'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    env:
+      IS_CICD: 1
+      RELEASE_SKIP_TESTS: ${{ inputs.skip-tests }}
+      RELEASE_VERSION: ${{ inputs.release-version }}
+      RELEASE_TARGET_TAG: ${{ inputs.target-tag }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target-tag }}
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Checkout Code One Commit Before ${{ inputs.target-tag }}
+        if: inputs.target-tag != 'main'
+        run: make checkout-one-commit-before
+
+      - name: Restore
+        run: dotnet restore ScyllaDB.Alternator.sln --verbosity minimal
+
+      - name: Prepare release
+        run: make release-prepare
+
+      - name: Perform release
+        if: inputs.dry-run == false
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: make release-push
+
+      - name: Perform release dry-run
+        if: inputs.dry-run == true
+        run: make release-dry-run-summary
+
+      - name: Upload NuGet package
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: nuget-package
+          path: nupkgs/*.nupkg

--- a/IntegrationTests/IntegrationTests.cs
+++ b/IntegrationTests/IntegrationTests.cs
@@ -12,9 +12,11 @@ namespace ScyllaDB.Alternator
     [Category("Integration")]
     public class IntegrationTests
     {
-        private readonly string user = TestContext.Parameters.Get("User", "none");
-        private readonly string password = TestContext.Parameters.Get("Password", "none");
-        private readonly string endpoint = TestContext.Parameters.Get("Endpoint", "http://127.0.0.1:8080");
+        private readonly string user = Environment.GetEnvironmentVariable("ALTERNATOR_USER") ?? TestContext.Parameters.Get("User", "none");
+        private readonly string password = Environment.GetEnvironmentVariable("ALTERNATOR_PASSWORD") ?? TestContext.Parameters.Get("Password", "none");
+        private readonly string endpoint = Environment.GetEnvironmentVariable("ALTERNATOR_ENDPOINT") ?? TestContext.Parameters.Get("Endpoint", "http://127.0.0.1:8080");
+        private readonly string httpsEndpoint = Environment.GetEnvironmentVariable("ALTERNATOR_HTTPS_ENDPOINT") ?? TestContext.Parameters.Get("HttpsEndpoint", "https://172.45.0.2:9999");
+        private readonly string caCertPath = Environment.GetEnvironmentVariable("ALTERNATOR_CA_CERT_PATH") ?? TestContext.Parameters.Get("CaCertPath", "IntegrationTests/scylla/db.crt");
 
         public IntegrationTests()
         {
@@ -23,12 +25,160 @@ namespace ScyllaDB.Alternator
         [Test]
         public async Task BasicTableTest([Values("", "dc1")] string datacenter, [Values("", "rack1")] string rack)
         {
-            var credentials = new BasicAWSCredentials(this.user, this.password);
-            var ddb = GetAlternatorClient(new Uri(this.endpoint), credentials, datacenter, rack);
-            var rand = new Random();
-            string tabName = "table" + rand.Next(1000000);
+            using var ddb = this.GetAlternatorClient(new Uri(this.endpoint), datacenter, rack);
+            var tableName = CreateTableName("basic");
+
+            try
+            {
+                await CreateNumberRangeTableAsync(ddb, tableName);
+                for (int i = 0; i < 10; i++)
+                {
+                    var tables = await ddb.ListTablesAsync();
+                    Assert.That(tables.TableNames, Does.Contain(tableName));
+                }
+            }
+            finally
+            {
+                await DeleteTableIfExistsAsync(ddb, tableName);
+            }
+        }
+
+        [Test]
+        public async Task BuildReturnsRegularAwsClientThatPerformsCrudTest()
+        {
+            using var ddb = this.CreateBuilder(new Uri(this.endpoint)).Build();
+            var tableName = CreateTableName("crud");
+
+            try
+            {
+                await CreateStringTableAsync(ddb, tableName);
+                var key = StringKey("item-1");
+                await ddb.PutItemAsync(new PutItemRequest
+                {
+                    TableName = tableName,
+                    Item = new Dictionary<string, AttributeValue>(key)
+                    {
+                        ["payload"] = new AttributeValue { S = "value-1" },
+                    },
+                });
+
+                var loaded = await ddb.GetItemAsync(new GetItemRequest
+                {
+                    TableName = tableName,
+                    Key = key,
+                    ConsistentRead = true,
+                });
+
+                Assert.That(loaded.Item, Does.ContainKey("payload"));
+                Assert.That(loaded.Item["payload"].S, Is.EqualTo("value-1"));
+
+                await ddb.DeleteItemAsync(new DeleteItemRequest
+                {
+                    TableName = tableName,
+                    Key = key,
+                });
+
+                var deleted = await ddb.GetItemAsync(new GetItemRequest
+                {
+                    TableName = tableName,
+                    Key = key,
+                    ConsistentRead = true,
+                });
+                Assert.That(deleted.Item == null || deleted.Item.Count == 0, Is.True);
+            }
+            finally
+            {
+                await DeleteTableIfExistsAsync(ddb, tableName);
+            }
+        }
+
+        [Test]
+        public async Task WrapperExposesAlternatorApiAndLiveNodesTest()
+        {
+            using var wrapper = this.CreateBuilder(new Uri(this.endpoint))
+                .WithActiveRefreshIntervalMs(200)
+                .WithIdleRefreshIntervalMs(1000)
+                .BuildWithAlternatorAPI();
+
+            await WaitUntilAsync(() => wrapper.getLiveNodes().Count > 0);
+            var liveNodes = wrapper.getLiveNodes();
+            var next = wrapper.nextAsURI();
+            var config = wrapper.GetAlternatorConfig();
+
+            Assert.That(wrapper.getClient(), Is.InstanceOf<AmazonDynamoDBClient>());
+            Assert.That(config, Is.Not.Null);
+            Assert.That(config!.SeedHosts, Is.Not.Empty);
+            Assert.That(wrapper.getAlternatorLiveNodes().getLiveNodes(), Is.EqualTo(liveNodes));
+            Assert.That(liveNodes, Does.Contain(next));
+        }
+
+        [Test]
+        public async Task CompressionAndHeaderOptimizationClientCanSendCompressedRequestTest()
+        {
+            var requiredHeaders = AlternatorConfig.builder()
+                .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+                .getRequiredHeaders();
+
+            using var ddb = this.CreateBuilder(new Uri(this.endpoint))
+                .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+                .withMinCompressionSizeBytes(1)
+                .withOptimizeHeaders(true)
+                .withHeadersWhitelist(requiredHeaders)
+                .Build();
+
+            try
+            {
+                await ddb.PutItemAsync(new PutItemRequest
+                {
+                    TableName = "nonexistent_table_for_combined_test",
+                    Item = new Dictionary<string, AttributeValue>
+                    {
+                        ["pk"] = new AttributeValue { S = "k" },
+                        ["data"] = new AttributeValue { S = LargePayload() },
+                    },
+                });
+                Assert.Fail("PutItem should fail after Alternator receives and parses the compressed request.");
+            }
+            catch (ResourceNotFoundException)
+            {
+            }
+        }
+
+        [Test]
+        public async Task HttpsTrustAllClientCanListTablesTest()
+        {
+            using var ddb = this.CreateBuilder(new Uri(this.httpsEndpoint))
+                .withTlsConfig(TlsConfig.trustAll())
+                .Build();
+
+            var tables = await ddb.ListTablesAsync();
+            Assert.That(tables.TableNames, Is.Not.Null);
+        }
+
+        [Test]
+        public async Task HttpsCustomCaClientCanListTablesTest()
+        {
+            var tlsConfig = TlsConfig.builder()
+                .withCaCertPath(this.caCertPath)
+                .withTrustSystemCaCerts(false)
+                .build();
+            using var ddb = this.CreateBuilder(new Uri(this.httpsEndpoint))
+                .withTlsConfig(tlsConfig)
+                .Build();
+
+            var tables = await ddb.ListTablesAsync();
+            Assert.That(tables.TableNames, Is.Not.Null);
+        }
+
+        private static string CreateTableName(string prefix)
+        {
+            return "csharp_it_" + prefix + "_" + Guid.NewGuid().ToString("N");
+        }
+
+        private static async Task CreateNumberRangeTableAsync(AmazonDynamoDBClient ddb, string tableName)
+        {
             await ddb.CreateTableAsync(
-                tabName,
+                tableName,
                 new List<KeySchemaElement>
                 {
                     new KeySchemaElement("k", KeyType.HASH),
@@ -40,31 +190,76 @@ namespace ScyllaDB.Alternator
                     new AttributeDefinition("c", ScalarAttributeType.N),
                 },
                 new ProvisionedThroughput { ReadCapacityUnits = 1, WriteCapacityUnits = 1 });
-            for (int i = 0; i < 10; i++)
+        }
+
+        private static async Task CreateStringTableAsync(AmazonDynamoDBClient ddb, string tableName)
+        {
+            await ddb.CreateTableAsync(
+                tableName,
+                new List<KeySchemaElement>
+                {
+                    new KeySchemaElement("pk", KeyType.HASH),
+                },
+                new List<AttributeDefinition>
+                {
+                    new AttributeDefinition("pk", ScalarAttributeType.S),
+                },
+                new ProvisionedThroughput { ReadCapacityUnits = 1, WriteCapacityUnits = 1 });
+        }
+
+        private static async Task DeleteTableIfExistsAsync(AmazonDynamoDBClient ddb, string tableName)
+        {
+            try
             {
-                var tables = await ddb.ListTablesAsync();
-                Console.WriteLine(tables);
+                await ddb.DeleteTableAsync(tableName);
+            }
+            catch (ResourceNotFoundException)
+            {
+            }
+        }
+
+        private static Dictionary<string, AttributeValue> StringKey(string key)
+        {
+            return new Dictionary<string, AttributeValue>
+            {
+                ["pk"] = new AttributeValue { S = key },
+            };
+        }
+
+        private static string LargePayload()
+        {
+            return string.Concat(Enumerable.Repeat("This is a test value that should be compressed. ", 100));
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> condition)
+        {
+            var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
+            while (DateTimeOffset.UtcNow < deadline)
+            {
+                if (condition())
+                {
+                    return;
+                }
+
+                await Task.Delay(100);
             }
 
-            await ddb.DeleteTableAsync(tabName);
-            ddb.Dispose();
+            Assert.That(condition(), Is.True);
         }
 
         // Alternator-specific DynamoDB connection
-        private static AmazonDynamoDBClient GetAlternatorClient(Uri uri, AWSCredentials credentials, string datacenter, string rack)
+        private AmazonDynamoDBClient GetAlternatorClient(Uri uri, string datacenter, string rack)
         {
-            var handler = new Helper(
-                HelperOptionsBuilder.Create()
-                    .WithInitialNodeUri(uri)
-                    .WithDatacenter(datacenter)
-                    .WithRack(rack)
-                    .Build());
-            var config = new AmazonDynamoDBConfig
-            {
-                RegionEndpoint = Amazon.RegionEndpoint.USEast1,
-                EndpointProvider = handler,
-            };
-            return new AmazonDynamoDBClient(credentials, config);
+            return this.CreateBuilder(uri)
+                .WithDatacenterAndRack(datacenter, rack)
+                .Build();
+        }
+
+        private AlternatorDynamoDBClientBuilder CreateBuilder(Uri uri)
+        {
+            return AlternatorDynamoDBClient.builder()
+                .endpointOverride(uri)
+                .credentialsProvider(new BasicAWSCredentials(this.user, this.password));
         }
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+SHELL := bash
+.ONESHELL:
+.SHELLFLAGS := -eo pipefail -c
+
 define dl_tgz
 	@if ! $(1) 2>/dev/null 1>&2; then \
 		[ -d "$(GOBIN)" ] || mkdir "$(GOBIN)"; \
@@ -26,7 +30,18 @@ MAKEFILE_PATH := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 ARCH := $(shell uname -m)
 OS := $(shell uname -s | tr A-Z a-z)
 
-DOCKER_COMPOSE_DOWNLOAD_URL := "https://github.com/docker/compose/releases/download/v$(DOCKER_COMPOSE_VERSION)/docker-compose-$(OS)-$(GOARCH)"
+ifeq ($(ARCH),aarch64)
+	DOCKER_COMPOSE_DOWNLOAD_URL := "https://github.com/docker/compose/releases/download/v$(DOCKER_COMPOSE_VERSION)/docker-compose-$(OS)-aarch64"
+else ifeq ($(ARCH),x86_64)
+	DOCKER_COMPOSE_DOWNLOAD_URL := "https://github.com/docker/compose/releases/download/v$(DOCKER_COMPOSE_VERSION)/docker-compose-$(OS)-x86_64"
+else
+	$(error Unknown architecture "$(ARCH)")
+endif
+
+DOTNET_VERBOSITY := normal
+ifdef IS_CICD
+	DOTNET_VERBOSITY := minimal
+endif
 
 
 ifndef GOBIN
@@ -36,19 +51,146 @@ endif
 export PATH := $(GOBIN):$(PATH)
 
 COMPOSE := docker-compose -f $(MAKEFILE_PATH)/IntegrationTests/docker-compose.yml
+ALTERNATOR_ENDPOINT ?= http://172.45.0.2:9998
+ALTERNATOR_HTTPS_ENDPOINT ?= https://172.45.0.2:9999
+ALTERNATOR_CA_CERT_PATH ?= $(CERT_DIR)/db.crt
+SCYLLA_IMAGE := scylladb/scylla:2025.2
+DOCKER_CACHE_DIR := $(MAKEFILE_PATH)/.docker-cache
+DOCKER_CACHE_FILE := $(DOCKER_CACHE_DIR)/scylla-image.tar
+CERT_CACHE_DIR := $(MAKEFILE_PATH)/.cert-cache
+CERT_DIR := $(MAKEFILE_PATH)/IntegrationTests/scylla
+PACKAGE_OUTPUT_DIR ?= $(MAKEFILE_PATH)/nupkgs
+NUGET_SOURCE ?= https://api.nuget.org/v3/index.json
+NUGET_API_KEY ?=
+RELEASE_SKIP_TESTS ?= false
+RELEASE_VERSION ?=
+PACK_VERSION_ARGS :=
+ifneq ($(strip $(RELEASE_VERSION)),)
+	PACK_VERSION_ARGS := /p:Version=$(RELEASE_VERSION) /p:PackageVersion=$(RELEASE_VERSION)
+endif
 
 .PHONY: clean
 clean:
 	dotnet clean ScyllaDB.Alternator.csproj
 	dotnet clean UnitTests/ScyllaDB.Alternator.Test.csproj
 	dotnet clean IntegrationTests/ScyllaDB.Alternator.Test.csproj
-	rm -rf bin/ obj/ UnitTests/bin/ UnitTests/obj/ IntegrationTests/bin/ IntegrationTests/obj/
+	rm -rf bin/ obj/ UnitTests/bin/ UnitTests/obj/ IntegrationTests/bin/ IntegrationTests/obj/ $(PACKAGE_OUTPUT_DIR)/
 
 .PHONY: build
 build:
-	dotnet build ScyllaDB.Alternator.csproj --configuration Release
-	dotnet build UnitTests/ScyllaDB.Alternator.Test.csproj --configuration Release
-	dotnet build IntegrationTests/ScyllaDB.Alternator.Test.csproj --configuration Release
+	dotnet build ScyllaDB.Alternator.csproj --configuration Release --verbosity $(DOTNET_VERBOSITY)
+	dotnet build UnitTests/ScyllaDB.Alternator.Test.csproj --configuration Release --verbosity $(DOTNET_VERBOSITY)
+	dotnet build IntegrationTests/ScyllaDB.Alternator.Test.csproj --configuration Release --verbosity $(DOTNET_VERBOSITY)
+
+.PHONY: verify
+verify: build check test-unit try-get
+
+.PHONY: lint
+lint: check
+
+.PHONY: lint-fix
+lint-fix: fix
+
+.PHONY: compile
+compile:
+	dotnet build ScyllaDB.Alternator.csproj --configuration Release --verbosity $(DOTNET_VERBOSITY)
+
+.PHONY: compile-test
+compile-test:
+	dotnet build UnitTests/ScyllaDB.Alternator.Test.csproj --configuration Release --verbosity $(DOTNET_VERBOSITY)
+	dotnet build IntegrationTests/ScyllaDB.Alternator.Test.csproj --configuration Release --verbosity $(DOTNET_VERBOSITY)
+
+.PHONY: compile-demo
+compile-demo: compile-test
+
+.PHONY: pack
+pack:
+	mkdir -p $(PACKAGE_OUTPUT_DIR)
+	dotnet pack ScyllaDB.Alternator.csproj --configuration Release --output $(PACKAGE_OUTPUT_DIR) --verbosity $(DOTNET_VERBOSITY) $(PACK_VERSION_ARGS)
+
+.PHONY: try-get
+try-get: pack
+	tmpdir=$$(mktemp -d)
+	trap 'rm -rf "$$tmpdir"' EXIT
+	local_source=$$(cd "$(PACKAGE_OUTPUT_DIR)" && pwd)
+	package_path=$$(ls -t "$$local_source"/ScyllaDB.Alternator.*.nupkg | head -n 1)
+	if [[ "$$package_path" == "" ]]; then
+		echo "No ScyllaDB.Alternator package found in $$local_source"
+		exit 1
+	fi
+	package_file=$$(basename "$$package_path")
+	package_version=$${package_file#ScyllaDB.Alternator.}
+	package_version=$${package_version%.nupkg}
+	printf '%s\n' \
+		'<?xml version="1.0" encoding="utf-8"?>' \
+		'<configuration>' \
+		'  <packageSources>' \
+		'    <clear />' \
+		"    <add key=\"local\" value=\"$$local_source\" />" \
+		"    <add key=\"nuget.org\" value=\"$(NUGET_SOURCE)\" />" \
+		'  </packageSources>' \
+		'  <packageSourceMapping>' \
+		'    <packageSource key="local">' \
+		'      <package pattern="ScyllaDB.Alternator" />' \
+		'    </packageSource>' \
+		'    <packageSource key="nuget.org">' \
+		'      <package pattern="*" />' \
+		'    </packageSource>' \
+		'  </packageSourceMapping>' \
+		'</configuration>' \
+		> "$$tmpdir/NuGet.config"
+	printf '%s\n' \
+		'<Project Sdk="Microsoft.NET.Sdk">' \
+		'  <PropertyGroup>' \
+		'    <OutputType>Exe</OutputType>' \
+		'    <TargetFramework>net8.0</TargetFramework>' \
+		'    <ImplicitUsings>enable</ImplicitUsings>' \
+		'    <Nullable>enable</Nullable>' \
+		'    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>' \
+		'  </PropertyGroup>' \
+		'</Project>' \
+		> "$$tmpdir/TryGet.csproj"
+	NUGET_PACKAGES="$$tmpdir/packages" dotnet add "$$tmpdir/TryGet.csproj" package ScyllaDB.Alternator --version "$$package_version"
+	printf '%s\n' \
+		'using System.Reflection;' \
+		'using Amazon.DynamoDBv2;' \
+		'using ScyllaDB.Alternator;' \
+		'using ScyllaDB.Alternator.Routing;' \
+		'' \
+		'using var client = AlternatorDynamoDBClient.builder()' \
+		'    .endpointOverride("http://127.0.0.1:8000")' \
+		'    .region("us-east-1")' \
+		'    .withRoutingScope(DatacenterScope.of("dc1", ClusterScope.create()))' \
+		'    .WithoutValidation()' \
+		'    .WithDeferredStart()' \
+		'    .build();' \
+		'' \
+		'if (client is not AmazonDynamoDBClient)' \
+		'{' \
+		'    throw new InvalidOperationException("builder().build() did not return AmazonDynamoDBClient.");' \
+		'}' \
+		'' \
+		'var config = AlternatorConfig.builder()' \
+		'    .withSeedNode("http://127.0.0.1:8000")' \
+		'    .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)' \
+		'    .withOptimizeHeaders(true)' \
+		'    .build();' \
+		'' \
+		'if (!config.getRequiredHeaders().Contains("Content-Encoding"))' \
+		'{' \
+		'    throw new InvalidOperationException("Packaged API did not expose compression headers.");' \
+		'}' \
+		'' \
+		'var assembly = typeof(AlternatorDynamoDBClient).Assembly;' \
+		'var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;' \
+		'if (string.IsNullOrWhiteSpace(informationalVersion) || informationalVersion == "0.0.0.0")' \
+		'{' \
+		'    throw new InvalidOperationException("Packaged assembly is missing informational version metadata.");' \
+		'}' \
+		'' \
+		'Console.WriteLine("Installed ScyllaDB.Alternator " + informationalVersion + " from NuGet package.");' \
+		> "$$tmpdir/Program.cs"
+	NUGET_PACKAGES="$$tmpdir/packages" dotnet run --project "$$tmpdir/TryGet.csproj" --no-restore --verbosity $(DOTNET_VERBOSITY)
 
 .PHONY: clean-caches
 clean-caches:
@@ -71,20 +213,86 @@ fix-dotnet-format:
 .PHONY: test
 test: build check test-unit test-integration
 
+.PHONY: test-all
+test-all: test
+
+.PHONY: release-prepare
+release-prepare:
+	@if [[ "$(RELEASE_SKIP_TESTS)" != "true" ]] && [[ "$(RELEASE_SKIP_TESTS)" != "1" ]]; then \
+		$(MAKE) build check test-unit; \
+	fi
+	$(MAKE) try-get
+
+.PHONY: release-push
+release-push:
+	@if [[ "$(NUGET_API_KEY)" == "" ]]; then \
+		echo "NUGET_API_KEY is empty, can't continue"; \
+		exit 1; \
+	fi
+	dotnet nuget push $(PACKAGE_OUTPUT_DIR)/*.nupkg --api-key "$(NUGET_API_KEY)" --source "$(NUGET_SOURCE)" --skip-duplicate
+
+.PHONY: release
+release: release-prepare release-push
+
+.PHONY: release-dry-run-summary
+release-dry-run-summary:
+	@echo "Dry-run: NuGet package was built but not pushed"
+	ls -l $(PACKAGE_OUTPUT_DIR)
+
+.PHONY: release-dry-run
+release-dry-run: release-prepare release-dry-run-summary
+
+.PHONY: checkout-one-commit-before
+checkout-one-commit-before:
+	@if [[ "$(RELEASE_TARGET_TAG)" != "" ]] && [[ "$(RELEASE_TARGET_TAG)" != "main" ]]; then \
+		git fetch --tags --prune --unshallow || git fetch --tags --prune || true; \
+		if git rev-parse -q --verify "refs/tags/$(RELEASE_TARGET_TAG)" >/dev/null; then \
+			echo "Checking out one commit before $(RELEASE_TARGET_TAG)"; \
+			cp -f Makefile /tmp/tmp-Makefile; \
+			git checkout "$(RELEASE_TARGET_TAG)~1"; \
+			git tag -d "$(RELEASE_TARGET_TAG)" || true; \
+			mv -f /tmp/tmp-Makefile ./Makefile; \
+		else \
+			echo "$(RELEASE_TARGET_TAG) is not a tag; leaving checkout unchanged"; \
+		fi; \
+	fi
+
 .PHONY: test-unit
 test-unit:
-	dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj --filter "Category=Unit" --logger:"console;verbosity=normal"
+	dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj --filter "Category=Unit" --logger:"console;verbosity=$(DOTNET_VERBOSITY)" --logger trx --results-directory UnitTests/TestResults --verbosity $(DOTNET_VERBOSITY)
 
 .PHONY: test-integration
-test-integration: scylla-start
-	dotnet test IntegrationTests/ScyllaDB.Alternator.Test.csproj --filter "Category=Integration" --logger:"console;verbosity=normal"
+test-integration: scylla-start wait-for-alternator
+	ALTERNATOR_ENDPOINT=$(ALTERNATOR_ENDPOINT) ALTERNATOR_HTTPS_ENDPOINT=$(ALTERNATOR_HTTPS_ENDPOINT) ALTERNATOR_CA_CERT_PATH=$(ALTERNATOR_CA_CERT_PATH) dotnet test IntegrationTests/ScyllaDB.Alternator.Test.csproj --filter "Category=Integration" --logger:"console;verbosity=$(DOTNET_VERBOSITY)" --logger trx --results-directory IntegrationTests/TestResults --verbosity $(DOTNET_VERBOSITY) || ($(MAKE) scylla-stop && exit 1)
+	$(MAKE) scylla-stop
+
+.PHONY: wait-for-alternator
+wait-for-alternator:
+	@echo "Waiting for Alternator to be ready..."
+	@for i in $$(seq 1 60); do \
+		if curl -sf $(ALTERNATOR_ENDPOINT)/ >/dev/null 2>&1; then \
+			echo "Alternator is ready (waited $${i}s)"; \
+			break; \
+		fi; \
+		if [ $$i -eq 60 ]; then \
+			echo "Timed out waiting for Alternator"; \
+			exit 1; \
+		fi; \
+		sleep 1; \
+	done
 
 .PHONY: .prepare-cert
 .prepare-cert:
-	@[ -f "${MAKEFILE_PATH}/IntegrationTests/scylla/db.key" ] || (echo "Prepare certificate" && cd ${MAKEFILE_PATH}/IntegrationTests/scylla/ && openssl req -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com" -x509 -newkey rsa:4096 -keyout db.key -out db.crt -days 3650 -nodes && chmod 644 db.key)
+	@if [ ! -f "$(CERT_DIR)/db.key" ] || [ ! -f "$(CERT_DIR)/db.crt" ] || ! openssl x509 -in "$(CERT_DIR)/db.crt" -noout -text | grep "IP Address:172.45.0.2" >/dev/null; then \
+		echo "Prepare certificate"; \
+		cd "$(CERT_DIR)"; \
+		rm -f db.key db.crt; \
+		openssl req -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com" -x509 -newkey rsa:4096 -keyout db.key -out db.crt -days 3650 -nodes -addext "subjectAltName=IP:172.45.0.2,IP:172.45.0.3,IP:172.45.0.4"; \
+		chmod 644 db.key; \
+	fi
 
 .PHONY: scylla-start
-scylla-start: .prepare-cert $(GOBIN)/docker-compose
+scylla-start: cert-cache-load $(GOBIN)/docker-compose docker-cache-load
 	@sudo sysctl -w fs.aio-max-nr=10485760
 	$(COMPOSE) up -d
 
@@ -102,3 +310,38 @@ scylla-rm: $(GOBIN)/docker-compose
 
 $(GOBIN)/docker-compose: Makefile
 	$(call dl_bin,docker-compose,$(DOCKER_COMPOSE_DOWNLOAD_URL))
+
+.PHONY: docker-pull
+docker-pull:
+	docker pull $(SCYLLA_IMAGE)
+
+.PHONY: docker-cache-save
+docker-cache-save: docker-pull
+	@mkdir -p $(DOCKER_CACHE_DIR)
+	docker save $(SCYLLA_IMAGE) -o $(DOCKER_CACHE_FILE)
+
+.PHONY: docker-cache-load
+docker-cache-load:
+	@if [ -f "$(DOCKER_CACHE_FILE)" ]; then \
+		echo "Loading Docker image from cache..."; \
+		docker load -i $(DOCKER_CACHE_FILE); \
+	else \
+		echo "Cache file not found, pulling image..."; \
+		$(MAKE) docker-pull; \
+	fi
+
+.PHONY: cert-cache-save
+cert-cache-save: .prepare-cert
+	@mkdir -p $(CERT_CACHE_DIR)
+	cp $(CERT_DIR)/db.key $(CERT_DIR)/db.crt $(CERT_CACHE_DIR)/
+
+.PHONY: cert-cache-load
+cert-cache-load:
+	@if [ -f "$(CERT_CACHE_DIR)/db.key" ] && [ -f "$(CERT_CACHE_DIR)/db.crt" ] && openssl x509 -in "$(CERT_CACHE_DIR)/db.crt" -noout -text | grep "IP Address:172.45.0.2" >/dev/null; then \
+		echo "Loading certificates from cache..."; \
+		cp $(CERT_CACHE_DIR)/db.key $(CERT_CACHE_DIR)/db.crt $(CERT_DIR)/; \
+		chmod 644 $(CERT_DIR)/db.key; \
+	else \
+		echo "Certificate cache not found or missing SANs, generating..."; \
+		$(MAKE) .prepare-cert; \
+	fi

--- a/README.md
+++ b/README.md
@@ -1,0 +1,317 @@
+# Alternator - Client-side load balancing - C#
+
+## Introduction
+
+`ScyllaDB.Alternator` adds client-side load balancing for ScyllaDB Alternator to the AWS SDK for .NET DynamoDB client.
+
+DynamoDB applications normally point at one endpoint. Alternator is a distributed cluster, so a client should spread requests across live Alternator nodes and keep working when one node fails. This library discovers Alternator nodes through `/localnodes`, maintains the live-node list in the background, and installs AWS SDK pipeline handlers that choose a node for each request.
+
+The library does not replace the AWS SDK. `AlternatorDynamoDBClient.builder().Build()` returns a regular `AmazonDynamoDBClient`, and DynamoDB operations use the normal C# AWS SDK API.
+
+## Add the Package
+
+```sh
+dotnet add package ScyllaDB.Alternator
+```
+
+For local development from this repository:
+
+```sh
+make build
+make pack
+```
+
+## Basic Usage
+
+```csharp
+using Amazon.DynamoDBv2;
+using Amazon.Runtime;
+using ScyllaDB.Alternator;
+
+var credentials = new BasicAWSCredentials("myuser", "mypassword");
+
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .credentialsProvider(credentials)
+    .build();
+```
+
+If Alternator authentication is disabled, credentials can be omitted. The builder uses anonymous AWS credentials internally.
+
+```csharp
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .build();
+```
+
+The builder also exposes C#-style method names:
+
+```csharp
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.Builder()
+    .EndpointOverride("http://127.0.0.1:8000")
+    .WithCredentials(credentials)
+    .Build();
+```
+
+## Alternator API Wrapper
+
+Use `buildWithAlternatorAPI()` when the application also needs Alternator-specific state, such as the live-node view.
+
+```csharp
+using var alternator = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .credentialsProvider(credentials)
+    .buildWithAlternatorAPI();
+
+AmazonDynamoDBClient client = alternator.getClient();
+IReadOnlyList<Uri> liveNodes = alternator.getLiveNodes();
+Uri nextNode = alternator.nextAsURI();
+AlternatorLiveNodes manager = alternator.getAlternatorLiveNodes();
+```
+
+The wrapper owns the DynamoDB client and live-node polling. Disposing the wrapper shuts down polling and disposes the client.
+
+## Routing Scope
+
+Routing scopes mirror the Java client API and support fallback chains.
+
+```csharp
+using ScyllaDB.Alternator.Routing;
+
+var scope = RackScope.of(
+    "dc1",
+    "rack1",
+    DatacenterScope.of("dc1", ClusterScope.create()));
+
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .credentialsProvider(credentials)
+    .withRoutingScope(scope)
+    .build();
+```
+
+Legacy datacenter/rack helpers remain available:
+
+```csharp
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.Create(
+    credentials,
+    new Uri("http://127.0.0.1:8000"),
+    datacenter: "dc1",
+    rack: "rack1");
+```
+
+## HTTP Client Configuration
+
+The .NET SDK uses `AmazonDynamoDBConfig.HttpClientFactory` for transport customization. The Alternator builder configures an internal factory so TLS, header filtering, compression, connection pool tuning, and endpoint routing stay active.
+
+Customize the default `SocketsHttpHandler` after Alternator defaults are applied:
+
+```csharp
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("https://127.0.0.1:8043")
+    .credentialsProvider(credentials)
+    .withMaxConnections(200)
+    .withConnectionTimeoutMs(5000)
+    .withSocketsHttpHandlerCustomizer(handler =>
+    {
+        handler.UseCookies = false;
+    })
+    .build();
+```
+
+`withHttpClientHandlerCustomizer(...)` remains available for callers that need the older `HttpClientHandler` API. That path cannot apply `SocketsHttpHandler`-only options such as pooled connection lifetime.
+
+Use `ConfigureAws(...)` for C# AWS SDK configuration that belongs on `AmazonDynamoDBConfig`:
+
+```csharp
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .credentialsProvider(credentials)
+    .ConfigureAws(config =>
+    {
+        config.Timeout = TimeSpan.FromSeconds(10);
+    })
+    .build();
+```
+
+You can also provide the regular AWS SDK .NET HTTP factory directly. Java-style aliases `httpClient(...)` and `httpClientBuilder(...)` are available, but take `Amazon.Runtime.HttpClientFactory` because that is the C# AWS SDK transport extension point.
+
+```csharp
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .credentialsProvider(credentials)
+    .httpClientFactory(myHttpClientFactory)
+    .build();
+```
+
+### Connection Pool Tuning
+
+```csharp
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .credentialsProvider(credentials)
+    .withMaxConnections(200)
+    .withConnectionMaxIdleTimeMs(30000)
+    .withConnectionTimeToLiveMs(60000)
+    .withConnectionAcquisitionTimeoutMs(5000)
+    .withConnectionTimeoutMs(3000)
+    .build();
+```
+
+| Setting | Default | Description |
+|---|---:|---|
+| `maxConnections` | 400 | Maximum connections per server. |
+| `connectionMaxIdleTimeMs` | 600000 | Maximum idle time for pooled connections. |
+| `connectionTimeToLiveMs` | 0 | Maximum lifetime for pooled connections; `0` means unlimited. |
+| `connectionAcquisitionTimeoutMs` | 10000 | Stored for Java API parity; .NET does not expose a separate per-pool acquisition timeout. |
+| `connectionTimeoutMs` | 15000 | Applied to `AmazonDynamoDBConfig.Timeout` and `SocketsHttpHandler.ConnectTimeout`. |
+
+## TLS
+
+TLS options are configured on the Alternator builder and applied to the AWS SDK HTTP client factory.
+
+```csharp
+var tls = TlsConfig.builder()
+    .withCaCertPath("/etc/scylla/alternator-ca.pem")
+    .withTrustSystemCaCerts(false)
+    .build();
+
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("https://127.0.0.1:8043")
+    .credentialsProvider(credentials)
+    .withTlsConfig(tls)
+    .build();
+```
+
+Convenience factories:
+
+```csharp
+TlsConfig trustAll = TlsConfig.trustAll();
+TlsConfig systemDefault = TlsConfig.systemDefault();
+```
+
+TLS session cache configuration mirrors the Java API:
+
+```csharp
+var sessionCache = TlsSessionCacheConfig.builder()
+    .withEnabled(true)
+    .withSessionCacheSize(1024)
+    .withSessionTimeoutSeconds(86400)
+    .build();
+
+var tls = TlsConfig.builder()
+    .withSessionCacheConfig(sessionCache)
+    .build();
+```
+
+## Compression and Header Optimization
+
+Request compression is installed in the AWS SDK runtime pipeline before request signing.
+
+```csharp
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .credentialsProvider(credentials)
+    .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+    .withMinCompressionSizeBytes(2048)
+    .build();
+```
+
+Header optimization filters outgoing HTTP headers to the configured whitelist.
+
+```csharp
+var configBuilder = AlternatorConfig.builder()
+    .withSeedNode("http://127.0.0.1:8000")
+    .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP);
+
+var headers = configBuilder.getRequiredHeaders();
+
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .credentialsProvider(credentials)
+    .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+    .withOptimizeHeaders(true)
+    .withHeadersWhitelist(headers)
+    .build();
+```
+
+## User-Agent
+
+By default, the client appends a ScyllaDB Alternator token to the AWS SDK user-agent. The builder can replace, transform, or remove the final user-agent.
+
+```csharp
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .withUserAgent(userAgent => userAgent + " my-app/1.0")
+    .build();
+```
+
+```csharp
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .withoutUserAgent()
+    .build();
+```
+
+## Key Route Affinity
+
+Key route affinity can route qualifying write requests for the same partition key through a deterministic Alternator node order. Retries advance through the same Java/Go-compatible seeded query plan. Partition-key names can be preconfigured, or they are discovered asynchronously with `DescribeTable` after the first qualifying request for a table.
+
+```csharp
+using ScyllaDB.Alternator.KeyRouting;
+
+var affinity = KeyRouteAffinityConfig.builder()
+    .withType(KeyRouteAffinity.RMW)
+    .withPkInfo("users", "user_id")
+    .build();
+
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .credentialsProvider(credentials)
+    .withKeyRouteAffinity(affinity)
+    .build();
+```
+
+For automatic partition-key discovery, omit `withPkInfo`. Requests use normal load balancing until discovery completes.
+
+```csharp
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .credentialsProvider(credentials)
+    .withKeyRouteAffinity(KeyRouteAffinity.ANY_WRITE)
+    .build();
+```
+
+## AlternatorLiveNodes
+
+`AlternatorLiveNodes` is exposed through `buildWithAlternatorAPI()` for advanced inspection and compatibility with Java-style examples.
+
+```csharp
+AlternatorLiveNodes liveNodes = alternator.getAlternatorLiveNodes();
+
+List<Uri> nodes = liveNodes.getLiveNodes();
+Uri localNodesEndpoint = liveNodes.nextAsURI("/localnodes", "dc=dc1");
+RoutingScope scope = liveNodes.getRoutingScope();
+```
+
+## Build, Test, and CI
+
+```sh
+make build
+make check
+make test-unit
+make test-integration
+```
+
+In CI, set `IS_CICD=1` for quieter `dotnet` output.
+
+The Makefile includes Java-repo-equivalent cache helpers for integration tests:
+
+```sh
+make docker-cache-save
+make docker-cache-load
+make cert-cache-save
+make cert-cache-load
+```
+
+`make test-integration` starts the Scylla/Alternator Docker Compose cluster, waits for Alternator, runs integration tests, and stops the cluster.

--- a/ScyllaDB.Alternator.csproj
+++ b/ScyllaDB.Alternator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-  <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
@@ -18,6 +18,7 @@
         <RepositoryUrl>https://github.com/scylladb/alternator-client-csharp</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -40,6 +41,10 @@
 
     <ItemGroup>
       <Folder Include="Helper\" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Include="README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add README/package readme metadata and local package install verification
- expand Makefile targets for packaging, release, CI verbosity, Docker/cert caching, and integration test orchestration
- expand CI to run lint, package install verification, unit tests, and Docker-backed integration tests
- add release and Jira sync workflows
- expand integration tests for builder(), regular AmazonDynamoDBClient CRUD, wrapper APIs, compression/header optimization, and TLS

## Verification
- dotnet restore ScyllaDB.Alternator.sln --verbosity minimal
- make build
- IS_CICD=1 make check
- IS_CICD=1 make test-unit
- IS_CICD=1 make try-get
- IS_CICD=1 make test-integration