### PR TITLE
Add initial seed host builder API

### DIFF
--- a/AlternatorDynamoDBClientBuilder.cs
+++ b/AlternatorDynamoDBClientBuilder.cs
@@ -90,6 +90,31 @@ namespace ScyllaDB.Alternator
             return this.EndpointOverride(new Uri(endpointOverride));
         }
 
+        public AlternatorDynamoDBClientBuilder WithInitialSeeds(IEnumerable<string> seedHosts)
+        {
+            if (seedHosts == null)
+            {
+                throw new ArgumentNullException(nameof(seedHosts));
+            }
+
+            return this.ConfigureInitialSeedHosts(seedHosts, nameof(seedHosts));
+        }
+
+        public AlternatorDynamoDBClientBuilder WithInitialSeeds(params string[] seedHosts)
+        {
+            if (seedHosts == null)
+            {
+                throw new ArgumentNullException(nameof(seedHosts));
+            }
+
+            return this.ConfigureInitialSeedHosts(seedHosts, nameof(seedHosts));
+        }
+
+        public AlternatorDynamoDBClientBuilder WithScheme(string scheme)
+        {
+            return this.WithSchema(scheme);
+        }
+
 #pragma warning disable SA1300, IDE1006
         public AlternatorDynamoDBClientBuilder endpointOverride(Uri endpointOverride)
         {
@@ -99,6 +124,31 @@ namespace ScyllaDB.Alternator
         public AlternatorDynamoDBClientBuilder endpointOverride(string endpointOverride)
         {
             return this.EndpointOverride(endpointOverride);
+        }
+
+        public AlternatorDynamoDBClientBuilder withInitialSeeds(IEnumerable<string> seedHosts)
+        {
+            return this.WithInitialSeeds(seedHosts);
+        }
+
+        public AlternatorDynamoDBClientBuilder withInitialSeeds(params string[] seedHosts)
+        {
+            return this.WithInitialSeeds(seedHosts);
+        }
+
+        public AlternatorDynamoDBClientBuilder withScheme(string scheme)
+        {
+            return this.WithScheme(scheme);
+        }
+
+        public AlternatorDynamoDBClientBuilder withSchema(string schema)
+        {
+            return this.WithSchema(schema);
+        }
+
+        public AlternatorDynamoDBClientBuilder withPort(int port)
+        {
+            return this.WithPort(port);
         }
 
         public AlternatorDynamoDBClientBuilder credentialsProvider(AWSCredentials credentials)
@@ -506,7 +556,7 @@ namespace ScyllaDB.Alternator
         public AlternatorDynamoDBClientBuilder EndpointProvider(IEndpointProvider endpointProvider)
         {
             throw new NotSupportedException(
-                "AlternatorDynamoDBClient does not support custom endpoint providers. Use EndpointOverride(Uri) to specify the seed endpoint instead.");
+                "AlternatorDynamoDBClient does not support custom endpoint providers. Use EndpointOverride(Uri) for one seed, or WithInitialSeeds(...) with WithScheme(...) and WithPort(...) for multiple seeds.");
         }
 
         public AlternatorDynamoDBClientBuilder EndpointDiscoveryEnabled(bool endpointDiscoveryEnabled)
@@ -805,6 +855,30 @@ namespace ScyllaDB.Alternator
                 .Build();
         }
 
+        private static List<string> NormalizeInitialSeedHosts(IEnumerable<string> seedHosts, string paramName)
+        {
+            var hosts = new List<string>();
+            foreach (var seedHost in seedHosts)
+            {
+                if (string.IsNullOrWhiteSpace(seedHost))
+                {
+                    throw new ArgumentException("Initial seed host cannot be null or empty.", paramName);
+                }
+
+                var host = seedHost.Trim();
+                if (Uri.CheckHostName(host) == UriHostNameType.Unknown)
+                {
+                    throw new ArgumentException(
+                        "Initial seed must be a DNS name or IP address without scheme or port.",
+                        paramName);
+                }
+
+                hosts.Add(host);
+            }
+
+            return hosts;
+        }
+
         private ClientArtifacts BuildClientArtifacts()
         {
             this.configBuilder.WithAuthenticationEnabled(this.credentials != null);
@@ -867,8 +941,33 @@ namespace ScyllaDB.Alternator
             if (alternatorConfig.SeedHosts.Count == 0)
             {
                 throw new InvalidOperationException(
-                    "endpointOverride must be set when using AlternatorDynamoDBClientBuilder. Call endpointOverride(Uri) with the seed Alternator node URI.");
+                    "endpointOverride or withInitialSeeds must be set when using AlternatorDynamoDBClientBuilder. Call endpointOverride(Uri) for one seed, or withInitialSeeds(...) with DNS/IP seed hosts.");
             }
+
+            if (string.IsNullOrWhiteSpace(alternatorConfig.Scheme))
+            {
+                throw new InvalidOperationException(
+                    "Alternator scheme must be set. Call endpointOverride(Uri) or withScheme(string).");
+            }
+
+            if (alternatorConfig.Port <= 0)
+            {
+                throw new InvalidOperationException(
+                    "Alternator port must be set. Call endpointOverride(Uri) or withPort(int).");
+            }
+        }
+
+        private AlternatorDynamoDBClientBuilder ConfigureInitialSeedHosts(IEnumerable<string> seedHosts, string paramName)
+        {
+            var hosts = NormalizeInitialSeedHosts(seedHosts, paramName);
+            if (hosts.Count == 0)
+            {
+                throw new ArgumentException("At least one initial seed host must be provided.", paramName);
+            }
+
+            this.optionsBuilder.WithInitialNodes(hosts);
+            this.configBuilder.WithSeedHosts(hosts);
+            return this;
         }
 
         private void ValidateHttpClientConfiguration(AmazonDynamoDBConfig dynamoDbConfig)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,27 @@ AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
     .build();
 ```
 
+For cluster-wide routing in a multi-datacenter deployment, configure working seed
+hosts from every datacenter. `ClusterScope.create()` uses the bare `/localnodes`
+endpoint, and Alternator returns the nodes visible from the node that handled
+that request. With only one seed, discovery usually covers only that seed node's
+datacenter, so cluster scope will not route across datacenters unless the client
+is given reachable seeds from all datacenters.
+
+```csharp
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .withScheme("https")
+    .withPort(8043)
+    .withInitialSeeds(
+        "dc1-seed.example.com",
+        "dc2-seed.example.com")
+    .withRoutingScope(ClusterScope.create())
+    .build();
+```
+
+Seeds passed to `withInitialSeeds(...)` are DNS names or IP addresses only. The
+scheme and port are shared by all seeds and are configured separately.
+
 Legacy datacenter/rack helpers remain available:
 
 ```csharp

--- a/Routing/ClusterScope.cs
+++ b/Routing/ClusterScope.cs
@@ -4,6 +4,15 @@
 
 namespace ScyllaDB.Alternator.Routing
 {
+    /// <summary>
+    /// Routes requests across the unfiltered node list returned by the bare /localnodes endpoint.
+    /// </summary>
+    /// <remarks>
+    /// Alternator usually returns only the nodes visible from the node that handled /localnodes.
+    /// In multi-datacenter deployments, callers must provide reachable seed hosts from every
+    /// datacenter; otherwise cluster scope cannot discover or route through the missing
+    /// datacenters.
+    /// </remarks>
     public sealed class ClusterScope : RoutingScope
     {
         private static readonly ClusterScope Instance = new ClusterScope();

--- a/UnitTests/ClientBuilderUnitTests.cs
+++ b/UnitTests/ClientBuilderUnitTests.cs
@@ -67,6 +67,66 @@ namespace ScyllaDB.Alternator
         }
 
         [Test]
+        public void AlternatorDynamoDBClientBuilderSupportsInitialSeedsTest()
+        {
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .withScheme("https")
+                .withPort(8043)
+                .withInitialSeeds(
+                    "dc1-seed.example.com",
+                    "dc2-seed.example.com")
+                .withRoutingScope(ClusterScope.create())
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+
+            Assert.That(wrapper.Config.getSeedHosts(), Is.EqualTo(new[] { "dc1-seed.example.com", "dc2-seed.example.com" }));
+            Assert.That(wrapper.Config.getScheme(), Is.EqualTo("https"));
+            Assert.That(wrapper.Config.getPort(), Is.EqualTo(8043));
+            Assert.That(wrapper.getLiveNodes(), Is.EqualTo(new[]
+            {
+                new Uri("https://dc1-seed.example.com:8043"),
+                new Uri("https://dc2-seed.example.com:8043"),
+            }));
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderRejectsInitialSeedsThatAreNotHostsTest()
+        {
+            var uriException = Assert.Throws<ArgumentException>(() =>
+                AlternatorDynamoDBClient.builder()
+                    .withInitialSeeds("https://dc1-seed.example.com:8043"));
+            Assert.That(uriException!.Message, Does.Contain("DNS name or IP address"));
+
+            var hostPortException = Assert.Throws<ArgumentException>(() =>
+                AlternatorDynamoDBClient.builder()
+                    .WithInitialSeeds("dc1-seed.example.com:8043"));
+            Assert.That(hostPortException!.Message, Does.Contain("without scheme or port"));
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderRequiresSchemeAndPortForInitialSeedsTest()
+        {
+            var schemeException = Assert.Throws<InvalidOperationException>(() =>
+                AlternatorDynamoDBClient.builder()
+                    .withPort(8043)
+                    .withInitialSeeds("dc1-seed.example.com")
+                    .WithoutValidation()
+                    .WithDeferredStart()
+                    .build());
+            Assert.That(schemeException!.Message, Does.Contain("scheme must be set"));
+
+            var portException = Assert.Throws<InvalidOperationException>(() =>
+                AlternatorDynamoDBClient.builder()
+                    .withScheme("https")
+                    .withInitialSeeds("dc1-seed.example.com")
+                    .WithoutValidation()
+                    .WithDeferredStart()
+                    .build());
+            Assert.That(portException!.Message, Does.Contain("port must be set"));
+        }
+
+        [Test]
         public void AlternatorDynamoDBClientBuilderBuildsWrapperWithAlternatorApiTest()
         {
             using var wrapper = AlternatorDynamoDBClient.builder()
@@ -95,7 +155,7 @@ namespace ScyllaDB.Alternator
                     .WithDeferredStart()
                     .build());
 
-            Assert.That(exception!.Message, Does.Contain("endpointOverride must be set"));
+            Assert.That(exception!.Message, Does.Contain("endpointOverride or withInitialSeeds must be set"));
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- add `WithInitialSeeds(...)` / `withInitialSeeds(...)` to configure one or more Alternator seed hosts as DNS names or IP addresses
- add `WithScheme(...)` / `withScheme(...)` and `withPort(...)` so all initial seeds share one scheme and port
- reject URI or host:port values passed to `withInitialSeeds(...)`

Part 1 of the issue #31 split. The follow-up docs PR carries `Fixes #31`.

## Verification
- `dotnet restore ScyllaDB.Alternator.sln --verbosity minimal`
- `IS_CICD=1 make build`
- `IS_CICD=1 make check`
- `IS_CICD=1 make test-unit`