### PR TITLE
Document cluster-scope seed requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,27 @@ AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
     .build();
 ```
 
+For cluster-wide routing in a multi-datacenter deployment, configure working seed
+hosts from every datacenter. `ClusterScope.create()` uses the bare `/localnodes`
+endpoint, and Alternator returns the nodes visible from the node that handled
+that request. With only one seed, discovery usually covers only that seed node's
+datacenter, so cluster scope will not route across datacenters unless the client
+is given reachable seeds from all datacenters.
+
+```csharp
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .withScheme("https")
+    .withPort(8043)
+    .withInitialSeeds(
+        "dc1-seed.example.com",
+        "dc2-seed.example.com")
+    .withRoutingScope(ClusterScope.create())
+    .build();
+```
+
+Seeds passed to `withInitialSeeds(...)` are DNS names or IP addresses only. The
+scheme and port are shared by all seeds and are configured separately.
+
 Legacy datacenter/rack helpers remain available:
 
 ```csharp

--- a/Routing/ClusterScope.cs
+++ b/Routing/ClusterScope.cs
@@ -4,6 +4,15 @@
 
 namespace ScyllaDB.Alternator.Routing
 {
+    /// <summary>
+    /// Routes requests across the unfiltered node list returned by the bare /localnodes endpoint.
+    /// </summary>
+    /// <remarks>
+    /// Alternator usually returns only the nodes visible from the node that handled /localnodes.
+    /// In multi-datacenter deployments, callers must provide reachable seed hosts from every
+    /// datacenter; otherwise cluster scope cannot discover or route through the missing
+    /// datacenters.
+    /// </remarks>
     public sealed class ClusterScope : RoutingScope
     {
         private static readonly ClusterScope Instance = new ClusterScope();


### PR DESCRIPTION
## Summary
- document that `ClusterScope` uses bare `/localnodes`, which usually discovers only nodes visible from the contacted node's datacenter
- mention that cluster scope will not route across datacenters unless users provide reachable seed hosts from every datacenter
- show the seed-host API from #39 with shared scheme and port

Depends on #39.
Fixes #31

## Verification
- `dotnet restore ScyllaDB.Alternator.sln --verbosity minimal`
- `IS_CICD=1 make build`
- `IS_CICD=1 make check`
- `IS_CICD=1 make test-unit`