### PR TITLE
Retry discovery through configured seeds

### DIFF
--- a/AlternatorLiveNodes.cs
+++ b/AlternatorLiveNodes.cs
@@ -267,24 +267,26 @@ namespace ScyllaDB.Alternator
 
         public void CheckIfRackAndDatacenterSetCorrectly()
         {
-            var query = this.config.RoutingScope.LocalNodesQuery;
-            if (string.IsNullOrEmpty(query))
+            var scope = this.config.RoutingScope;
+            if (string.IsNullOrEmpty(scope.LocalNodesQuery))
             {
                 return;
             }
 
+            List<Uri> nodes;
             try
             {
-                var nodes = this.GetNodes(this.NextAsUri("/localnodes", query));
-                if (nodes.Count == 0)
-                {
-                    throw new ValidationError(
-                        $"node returned empty list for {this.config.RoutingScope.Description}, routing scope may be set incorrectly");
-                }
+                nodes = this.GetNodesForScope(scope);
             }
-            catch (IOException e)
+            catch (Exception e)
             {
                 throw new FailedToCheck("failed to read list of nodes from the node", e);
+            }
+
+            if (nodes.Count == 0)
+            {
+                throw new ValidationError(
+                    $"node returned empty list for {scope.Description}, routing scope may be set incorrectly");
             }
         }
 
@@ -641,11 +643,9 @@ namespace ScyllaDB.Alternator
             Exception? lastException = null;
             while (scope != null)
             {
-                var query = scope.LocalNodesQuery;
-                var uri = this.NextAsUri("/localnodes", string.IsNullOrEmpty(query) ? null : query);
                 try
                 {
-                    var nodes = this.GetNodes(uri);
+                    var nodes = this.GetNodesForScope(scope);
                     if (nodes.Count != 0)
                     {
                         var mergedNodes = this.MergeWithInitialNodes(nodes);
@@ -656,7 +656,7 @@ namespace ScyllaDB.Alternator
                 }
                 catch (Exception e)
                 {
-                    Logger.Warn(e, $"Failed to contact node {uri} for {scope.Description}");
+                    Logger.Warn(e, $"Failed to discover nodes for {scope.Description}");
                     lastException = e;
                 }
 
@@ -676,6 +676,57 @@ namespace ScyllaDB.Alternator
             }
 
             Logger.Warn("No nodes found in any routing scope, keeping existing node list");
+        }
+
+        private List<Uri> GetNodesForScope(RoutingScope scope)
+        {
+            var query = scope.LocalNodesQuery;
+            var requestQuery = string.IsNullOrEmpty(query) ? null : query;
+            Exception? lastException = null;
+            var nodes = new List<Uri>();
+            var seen = new HashSet<Uri>();
+            foreach (var seedNode in this.initialNodes)
+            {
+                var uri = BuildUri(seedNode, "/localnodes", requestQuery);
+                try
+                {
+                    var seedNodes = this.GetNodes(uri);
+                    if (seedNodes.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    if (scope is not ClusterScope)
+                    {
+                        return seedNodes;
+                    }
+
+                    foreach (var node in seedNodes)
+                    {
+                        if (seen.Add(node))
+                        {
+                            nodes.Add(node);
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    Logger.Warn(e, $"Failed to contact seed node {seedNode} for {scope.Description}");
+                    lastException = e;
+                }
+            }
+
+            if (nodes.Count != 0)
+            {
+                return nodes;
+            }
+
+            if (lastException != null)
+            {
+                throw lastException;
+            }
+
+            return new List<Uri>();
         }
 
         private List<Uri> GetNodes(Uri uri)

--- a/UnitTests/AlternatorLiveNodesUnitTests.cs
+++ b/UnitTests/AlternatorLiveNodesUnitTests.cs
@@ -130,6 +130,123 @@ namespace ScyllaDB.Alternator
         }
 
         [Test]
+        public void ClusterScopePollsAllSeedNodesAndMergesResultsTest()
+        {
+            var handler = new DiscoveryHttpMessageHandler(new Dictionary<string, string>
+            {
+                ["dc1-node1.example.com"] = "[\"dc1-node1.example.com\",\"dc1-node2.example.com\"]",
+                ["dc2-node1.example.com"] = "[\"dc2-node1.example.com\",\"dc2-node2.example.com\"]",
+            });
+            using var pollingHttpClient = new HttpClient(handler);
+            var config = AlternatorConfig.builder()
+                .withSeedHosts(new[] { "dc1-node1.example.com", "dc2-node1.example.com" })
+                .withScheme("http")
+                .withPort(8000)
+                .withRoutingScope(ClusterScope.create())
+                .build();
+            var liveNodes = new AlternatorLiveNodes(config, pollingHttpClient);
+
+            InvokeUpdateLiveNodes(liveNodes);
+
+            Assert.That(
+                liveNodes.getLiveNodes().Select(node => node.Host),
+                Is.EqualTo(new[]
+                {
+                    "dc1-node1.example.com",
+                    "dc1-node2.example.com",
+                    "dc2-node1.example.com",
+                    "dc2-node2.example.com",
+                }));
+            Assert.That(
+                handler.RequestedUris.Select(uri => uri.Host),
+                Is.EqualTo(new[] { "dc1-node1.example.com", "dc2-node1.example.com" }));
+            Assert.That(handler.RequestedUris.Select(uri => uri.AbsolutePath), Is.All.EqualTo("/localnodes"));
+            Assert.That(handler.RequestedUris.Select(uri => uri.Query), Is.All.Empty);
+        }
+
+        [Test]
+        public void ClusterScopeKeepsSuccessfulDiscoveryWhenAnotherSeedFailsTest()
+        {
+            var handler = new DiscoveryHttpMessageHandler(
+                new Dictionary<string, string>
+                {
+                    ["dc1-node1.example.com"] = "[\"dc1-node1.example.com\"]",
+                },
+                new HashSet<string> { "dc2-node1.example.com" });
+            using var pollingHttpClient = new HttpClient(handler);
+            var config = AlternatorConfig.builder()
+                .withSeedHosts(new[] { "dc1-node1.example.com", "dc2-node1.example.com" })
+                .withScheme("http")
+                .withPort(8000)
+                .withRoutingScope(ClusterScope.create())
+                .build();
+            var liveNodes = new AlternatorLiveNodes(config, pollingHttpClient);
+
+            InvokeUpdateLiveNodes(liveNodes);
+
+            Assert.That(
+                liveNodes.getLiveNodes().Select(node => node.Host),
+                Is.EqualTo(new[] { "dc1-node1.example.com", "dc2-node1.example.com" }));
+            Assert.That(
+                handler.RequestedUris.Select(uri => uri.Host),
+                Is.EqualTo(new[] { "dc1-node1.example.com", "dc2-node1.example.com" }));
+        }
+
+        [Test]
+        public void RackScopeRetriesNextSeedWhenFirstSeedReportsNoNodesTest()
+        {
+            var handler = new DiscoveryHttpMessageHandler(new Dictionary<string, string>
+            {
+                ["dc2-node1.example.com"] = "[]",
+                ["dc1-node1.example.com"] = "[\"dc1-rack1-node.example.com\"]",
+            });
+            using var pollingHttpClient = new HttpClient(handler);
+            var config = AlternatorConfig.builder()
+                .withSeedHosts(new[] { "dc2-node1.example.com", "dc1-node1.example.com" })
+                .withScheme("http")
+                .withPort(8000)
+                .withRoutingScope(RackScope.of("dc1", "rack1", DatacenterScope.of("dc1", ClusterScope.create())))
+                .build();
+            var liveNodes = new AlternatorLiveNodes(config, pollingHttpClient);
+
+            InvokeUpdateLiveNodes(liveNodes);
+
+            Assert.That(
+                liveNodes.getLiveNodes().Select(node => node.Host),
+                Is.EqualTo(new[] { "dc1-rack1-node.example.com", "dc2-node1.example.com", "dc1-node1.example.com" }));
+            Assert.That(
+                handler.RequestedUris.Select(uri => uri.Host),
+                Is.EqualTo(new[] { "dc2-node1.example.com", "dc1-node1.example.com" }));
+            Assert.That(handler.RequestedUris.Select(uri => uri.AbsolutePath), Is.All.EqualTo("/localnodes"));
+            Assert.That(handler.RequestedUris.Select(uri => uri.Query), Is.All.EqualTo("?dc=dc1&rack=rack1"));
+        }
+
+        [Test]
+        public void CheckIfRackAndDatacenterSetCorrectlyRetriesNextSeedTest()
+        {
+            var handler = new DiscoveryHttpMessageHandler(new Dictionary<string, string>
+            {
+                ["dc2-node1.example.com"] = "[]",
+                ["dc1-node1.example.com"] = "[\"dc1-rack1-node.example.com\"]",
+            });
+            using var pollingHttpClient = new HttpClient(handler);
+            var config = AlternatorConfig.builder()
+                .withSeedHosts(new[] { "dc2-node1.example.com", "dc1-node1.example.com" })
+                .withScheme("http")
+                .withPort(8000)
+                .withRoutingScope(RackScope.of("dc1", "rack1", DatacenterScope.of("dc1", ClusterScope.create())))
+                .build();
+            var liveNodes = new AlternatorLiveNodes(config, pollingHttpClient);
+
+            liveNodes.checkIfRackAndDatacenterSetCorrectly();
+
+            Assert.That(
+                handler.RequestedUris.Select(uri => uri.Host),
+                Is.EqualTo(new[] { "dc2-node1.example.com", "dc1-node1.example.com" }));
+            Assert.That(handler.RequestedUris.Select(uri => uri.Query), Is.All.EqualTo("?dc=dc1&rack=rack1"));
+        }
+
+        [Test]
         public void PollingRequestIncludesJavaStyleKeepAliveAndHostHeadersTest()
         {
             using var server = new LocalNodesServer(1, _ => "[\"127.0.0.2\"]");
@@ -358,6 +475,42 @@ namespace ScyllaDB.Alternator
                 }
 
                 base.Dispose(disposing);
+            }
+        }
+
+        private sealed class DiscoveryHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly IReadOnlyDictionary<string, string> responsesByHost;
+            private readonly ISet<string> failingHosts;
+
+            internal DiscoveryHttpMessageHandler(
+                IReadOnlyDictionary<string, string> responsesByHost,
+                ISet<string>? failingHosts = null)
+            {
+                this.responsesByHost = responsesByHost;
+                this.failingHosts = failingHosts ?? new HashSet<string>();
+            }
+
+            internal List<Uri> RequestedUris { get; } = new List<Uri>();
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var uri = request.RequestUri ?? throw new InvalidOperationException("Request URI was not set.");
+                this.RequestedUris.Add(uri);
+                if (this.failingHosts.Contains(uri.Host))
+                {
+                    throw new HttpRequestException("simulated discovery failure for " + uri.Host);
+                }
+
+                if (!this.responsesByHost.TryGetValue(uri.Host, out var responseBody))
+                {
+                    throw new InvalidOperationException("Unexpected discovery host: " + uri.Host);
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
+                });
             }
         }
 


### PR DESCRIPTION
## Summary
- Query every configured seed when refreshing nodes for cluster-wide discovery.
- Aggregate seed responses for `ClusterScope`, and retry the next configured seed for rack/datacenter scopes when a seed reports no nodes.
- Use the same seed retry path for routing-scope validation.
- Add unit coverage for multi-seed cluster discovery, partial seed failure, rack-scope empty responses, and validation retries.

Fixes #31

## Tests
- `dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj --filter FullyQualifiedName~AlternatorLiveNodesUnitTests`
- `dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj`
- `make check`