### PR TITLE
Format IPv6 seed hosts and Host headers correctly

### DIFF
--- a/AlternatorLiveNodes.cs
+++ b/AlternatorLiveNodes.cs
@@ -607,7 +607,14 @@ namespace ScyllaDB.Alternator
 
         private Uri HostToUri(string host)
         {
-            return new Uri($"{this.alternatorScheme}://{host}:{this.alternatorPort}");
+            try
+            {
+                return new UriBuilder(this.alternatorScheme, host, this.alternatorPort).Uri;
+            }
+            catch (ArgumentException e)
+            {
+                throw new UriFormatException("Invalid host URI", e);
+            }
         }
 
         private int GetRefreshInterval()
@@ -681,7 +688,7 @@ namespace ScyllaDB.Alternator
         private List<Uri> GetNodes(Uri uri)
         {
             using var request = new HttpRequestMessage(HttpMethod.Get, uri);
-            request.Headers.Host = $"{uri.Host}:{uri.Port}";
+            request.Headers.Host = uri.Authority;
             request.Headers.Connection.Add("keep-alive");
             using var response = this.pollingHttpClient.SendAsync(request).Result;
             if (!response.IsSuccessStatusCode)

--- a/BasicQueryPlanInterceptor.cs
+++ b/BasicQueryPlanInterceptor.cs
@@ -75,7 +75,7 @@ namespace ScyllaDB.Alternator
 
             var target = queryPlan.Next();
             requestContext.Request.Endpoint = target;
-            requestContext.Request.Headers["Host"] = target.IsDefaultPort ? target.Host : $"{target.Host}:{target.Port}";
+            requestContext.Request.Headers["Host"] = target.Authority;
             requestContext.Request.Headers["Connection"] = "keep-alive";
         }
     }

--- a/UnitTests/AlternatorLiveNodesUnitTests.cs
+++ b/UnitTests/AlternatorLiveNodesUnitTests.cs
@@ -149,6 +149,30 @@ namespace ScyllaDB.Alternator
         }
 
         [Test]
+        public void PollingRequestFormatsIpv6HostHeadersAndDiscoveredNodesTest()
+        {
+            var handler = new TrackingHttpMessageHandler("[\"::2\"]");
+            using var pollingHttpClient = new HttpClient(handler);
+            var config = AlternatorConfig.builder()
+                .withSeedHost("::1")
+                .withScheme("http")
+                .withPort(8080)
+                .withRoutingScope(ClusterScope.create())
+                .build();
+            var liveNodes = new AlternatorLiveNodes(config, pollingHttpClient);
+
+            InvokeUpdateLiveNodes(liveNodes);
+
+            Assert.That(handler.LastRequestUri, Is.EqualTo(new Uri("http://[::1]:8080/localnodes")));
+            Assert.That(handler.LastHostHeader, Is.EqualTo("[::1]:8080"));
+            Assert.That(liveNodes.getLiveNodes(), Is.EqualTo(new[]
+            {
+                new Uri("http://[::2]:8080"),
+                new Uri("http://[::1]:8080"),
+            }));
+        }
+
+        [Test]
         public void ConstructorValidatesConfigurationLikeJavaTest()
         {
             var config = AlternatorConfig.builder()
@@ -334,19 +358,31 @@ namespace ScyllaDB.Alternator
 
         private sealed class TrackingHttpMessageHandler : HttpMessageHandler
         {
+            private readonly string responseBody;
             private int disposeCount;
             private int sendCount;
+
+            internal TrackingHttpMessageHandler(string responseBody = "[\"127.0.0.2\"]")
+            {
+                this.responseBody = responseBody;
+            }
 
             internal int DisposeCount => this.disposeCount;
 
             internal int SendCount => this.sendCount;
 
+            internal Uri? LastRequestUri { get; private set; }
+
+            internal string? LastHostHeader { get; private set; }
+
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 Interlocked.Increment(ref this.sendCount);
+                this.LastRequestUri = request.RequestUri;
+                this.LastHostHeader = request.Headers.Host;
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent("[\"127.0.0.2\"]", Encoding.UTF8, "application/json"),
+                    Content = new StringContent(this.responseBody, Encoding.UTF8, "application/json"),
                 });
             }
 

--- a/UnitTests/ClientBuilderUnitTests.cs
+++ b/UnitTests/ClientBuilderUnitTests.cs
@@ -91,6 +91,25 @@ namespace ScyllaDB.Alternator
         }
 
         [Test]
+        public void AlternatorDynamoDBClientBuilderSupportsIpv6InitialSeedsTest()
+        {
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .withScheme("http")
+                .withPort(8080)
+                .withInitialSeeds("::1")
+                .withRoutingScope(ClusterScope.create())
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+
+            Assert.That(wrapper.Config.getSeedHosts(), Is.EqualTo(new[] { "::1" }));
+            Assert.That(wrapper.getLiveNodes(), Is.EqualTo(new[]
+            {
+                new Uri("http://[::1]:8080"),
+            }));
+        }
+
+        [Test]
         public void AlternatorDynamoDBClientBuilderRejectsInitialSeedsThatAreNotHostsTest()
         {
             var uriException = Assert.Throws<ArgumentException>(() =>


### PR DESCRIPTION
## Summary
- Build seed and discovered host URIs with `UriBuilder` so IPv6 literals are bracketed correctly.
- Use `Uri.Authority` for polling and routed request `Host` headers.
- Add coverage for IPv6 initial seeds, polling Host headers, and discovered IPv6 nodes.

Fixes #44

## Tests
- `dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj --filter "FullyQualifiedName~ClientBuilderUnitTests|FullyQualifiedName~AlternatorLiveNodesUnitTests"`
- `dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj`
- `make check`