### PR TITLE
Use effective config for WithOptions live nodes

### DIFF
--- a/AlternatorDynamoDBClientBuilder.cs
+++ b/AlternatorDynamoDBClientBuilder.cs
@@ -897,7 +897,11 @@ namespace ScyllaDB.Alternator
             var dynamoDbConfig = this.GetOrCreateDynamoDbConfig();
             this.ValidateHttpClientConfiguration(dynamoDbConfig);
             var endpointProvider = this.options != null
-                ? new Helper(this.options)
+                ? new Helper(
+                    alternatorConfig,
+                    this.options.ValidateOnInitialization,
+                    this.options.StartImmediately,
+                    this.options.CancellationToken)
                 : new Helper(alternatorConfig, this.validateOnInitialization, this.startImmediately, this.cancellationToken);
 
             if (alternatorConfig.ConnectionTimeoutMs > 0)

--- a/UnitTests/ClientBuilderUnitTests.cs
+++ b/UnitTests/ClientBuilderUnitTests.cs
@@ -321,6 +321,28 @@ namespace ScyllaDB.Alternator
         }
 
         [Test]
+        public void AlternatorDynamoDBClientBuilderWithOptionsUsesEffectiveConfigForLiveNodesTest()
+        {
+            var strictTlsConfig = TlsConfig.systemDefault();
+            var options = HelperOptionsBuilder.Create()
+                .WithInitialNodeUri(new Uri("https://127.0.0.1:8181"))
+                .WithTlsConfig(strictTlsConfig)
+                .WithoutValidation()
+                .WithDeferredStart()
+                .Build();
+
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .WithOptions(options)
+                .WithDisableCertificateChecks()
+                .buildWithAlternatorAPI();
+
+            var liveNodesConfig = GetAlternatorLiveNodesConfig(wrapper.getAlternatorLiveNodes());
+            Assert.That(wrapper.Config.getTlsConfig().isTrustAllCertificates(), Is.True);
+            Assert.That(liveNodesConfig.getTlsConfig().isTrustAllCertificates(), Is.True);
+            Assert.That(wrapper.getAlternatorLiveNodes().isRunning(), Is.False);
+        }
+
+        [Test]
         public void AlternatorDynamoDBClientBuilderSupportsAwsBuilderParityMethodsTest()
         {
             var builder = AlternatorDynamoDBClient.builder()
@@ -618,6 +640,17 @@ namespace ScyllaDB.Alternator
 
             Assert.That(wrapper.PartitionKeyResolver, Is.Not.Null);
             Assert.That(wrapper.getAlternatorConfig(), Is.SameAs(wrapper.Config));
+        }
+
+        private static AlternatorConfig GetAlternatorLiveNodesConfig(AlternatorLiveNodes liveNodes)
+        {
+            var field = typeof(AlternatorLiveNodes).GetField(
+                "config",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            Assert.That(field, Is.Not.Null);
+            var value = field!.GetValue(liveNodes);
+            Assert.That(value, Is.Not.Null);
+            return (AlternatorConfig)value!;
         }
 
         private static async Task WaitUntilAsync(Func<bool> condition)


### PR DESCRIPTION
## Summary
- Construct the live-node helper from the effective `AlternatorConfig` in the `WithOptions` build path.
- Preserve `HelperOptions` validation, start, and cancellation settings when creating that helper.
- Add regression coverage for `WithOptions(...).WithDisableCertificateChecks()` so live-node polling and the DynamoDB transport use the same TLS config.

Fixes #45

## Tests
- `dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj --filter FullyQualifiedName~ClientBuilderUnitTests`
- `dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj`
- `make check`