### PR TITLE
Support TLS session resumption control

### DIFF
--- a/AlternatorHttpClientFactory.cs
+++ b/AlternatorHttpClientFactory.cs
@@ -64,6 +64,12 @@ namespace ScyllaDB.Alternator
             int maxConnections,
             Action<HttpClientHandler>? configureHandler = null)
         {
+            if (!tlsConfig.TlsSessionResumptionEnabled)
+            {
+                throw new NotSupportedException(
+                    "Disabling TLS session resumption is only supported by the default SocketsHttpHandler transport.");
+            }
+
             var handler = new HttpClientHandler
             {
                 MaxConnectionsPerServer = maxConnections,
@@ -94,6 +100,7 @@ namespace ScyllaDB.Alternator
                 PooledConnectionIdleTimeout = ToTimeout(config.ConnectionMaxIdleTimeMs),
                 PooledConnectionLifetime = ToTimeout(config.ConnectionTimeToLiveMs),
             };
+            handler.SslOptions.AllowTlsResume = config.TlsConfig.TlsSessionResumptionEnabled;
 
             if (config.ConnectionTimeoutMs > 0)
             {

--- a/README.md
+++ b/README.md
@@ -211,6 +211,22 @@ TlsConfig trustAll = TlsConfig.trustAll();
 TlsConfig systemDefault = TlsConfig.systemDefault();
 ```
 
+TLS session resumption, including TLS session tickets when the server supports
+them, is enabled by default on the default .NET `SocketsHttpHandler` transport.
+It can be disabled explicitly:
+
+```csharp
+var tls = TlsConfig.builder()
+    .withTlsSessionResumption(false)
+    .build();
+```
+
+.NET exposes the TLS resumption enable/disable switch but does not expose
+portable session ticket cache size or timeout controls through `HttpClient`.
+Use the default `SocketsHttpHandler` transport for this setting; the legacy
+`withHttpClientHandlerCustomizer(...)` path uses platform defaults and cannot
+disable TLS resumption.
+
 ## Compression and Header Optimization
 
 Request compression is installed in the AWS SDK runtime pipeline before request signing.

--- a/TlsConfig.cs
+++ b/TlsConfig.cs
@@ -12,7 +12,8 @@ namespace ScyllaDB.Alternator
             null,
             false,
             true,
-            false);
+            false,
+            true);
 
         private static readonly TlsConfig SystemDefaultInstance = new TlsConfig(
             new List<string>(),
@@ -20,6 +21,7 @@ namespace ScyllaDB.Alternator
             null,
             true,
             false,
+            true,
             true);
 
         internal TlsConfig(
@@ -28,7 +30,8 @@ namespace ScyllaDB.Alternator
             string? clientPrivateKeyPath,
             bool trustSystemCaCerts,
             bool trustAllCertificates,
-            bool verifyHostname)
+            bool verifyHostname,
+            bool tlsSessionResumptionEnabled)
         {
             this.CustomCaCertPaths = new List<string>(customCaCertPaths ?? Array.Empty<string>()).AsReadOnly();
             this.ClientCertificatePath = clientCertificatePath;
@@ -36,6 +39,7 @@ namespace ScyllaDB.Alternator
             this.TrustSystemCaCerts = trustSystemCaCerts;
             this.TrustAllCertificates = trustAllCertificates;
             this.VerifyHostname = verifyHostname;
+            this.TlsSessionResumptionEnabled = tlsSessionResumptionEnabled;
         }
 
         public IReadOnlyList<string> CustomCaCertPaths { get; }
@@ -51,6 +55,8 @@ namespace ScyllaDB.Alternator
         public bool TrustAllCertificates { get; }
 
         public bool VerifyHostname { get; }
+
+        public bool TlsSessionResumptionEnabled { get; }
 
         public static TlsConfig TrustAll()
         {
@@ -118,6 +124,11 @@ namespace ScyllaDB.Alternator
             return this.VerifyHostname;
         }
 
+        public bool isTlsSessionResumptionEnabled()
+        {
+            return this.TlsSessionResumptionEnabled;
+        }
+
 #pragma warning restore SA1300, IDE1006
 
         public override string ToString()
@@ -137,6 +148,8 @@ namespace ScyllaDB.Alternator
                 + this.TrustAllCertificates.ToString().ToLowerInvariant()
                 + ", verifyHostname="
                 + this.VerifyHostname.ToString().ToLowerInvariant()
+                + ", tlsSessionResumptionEnabled="
+                + this.TlsSessionResumptionEnabled.ToString().ToLowerInvariant()
                 + "}";
         }
 
@@ -146,6 +159,7 @@ namespace ScyllaDB.Alternator
                 && this.TrustSystemCaCerts == other.TrustSystemCaCerts
                 && this.TrustAllCertificates == other.TrustAllCertificates
                 && this.VerifyHostname == other.VerifyHostname
+                && this.TlsSessionResumptionEnabled == other.TlsSessionResumptionEnabled
                 && this.CustomCaCertPaths.SequenceEqual(other.CustomCaCertPaths)
                 && string.Equals(this.ClientCertificatePath, other.ClientCertificatePath, StringComparison.Ordinal)
                 && string.Equals(this.ClientPrivateKeyPath, other.ClientPrivateKeyPath, StringComparison.Ordinal);
@@ -164,6 +178,7 @@ namespace ScyllaDB.Alternator
             hash.Add(this.TrustSystemCaCerts);
             hash.Add(this.TrustAllCertificates);
             hash.Add(this.VerifyHostname);
+            hash.Add(this.TlsSessionResumptionEnabled);
             return hash.ToHashCode();
         }
     }

--- a/TlsConfigBuilder.cs
+++ b/TlsConfigBuilder.cs
@@ -12,6 +12,7 @@ namespace ScyllaDB.Alternator
         private bool trustSystemCaCerts = true;
         private bool trustAllCertificates;
         private bool verifyHostname = true;
+        private bool tlsSessionResumptionEnabled = true;
 
         public TlsConfigBuilder WithCaCertPath(string? path)
         {
@@ -76,6 +77,12 @@ namespace ScyllaDB.Alternator
             return this;
         }
 
+        public TlsConfigBuilder WithTlsSessionResumption(bool enabled)
+        {
+            this.tlsSessionResumptionEnabled = enabled;
+            return this;
+        }
+
         public TlsConfig Build()
         {
             if (!this.trustAllCertificates && !this.trustSystemCaCerts && this.customCaCertPaths.Count == 0)
@@ -90,7 +97,8 @@ namespace ScyllaDB.Alternator
                 this.clientPrivateKeyPath,
                 this.trustSystemCaCerts,
                 this.trustAllCertificates,
-                this.trustAllCertificates ? false : this.verifyHostname);
+                this.trustAllCertificates ? false : this.verifyHostname,
+                this.tlsSessionResumptionEnabled);
         }
 
 #pragma warning disable SA1300, IDE1006
@@ -122,6 +130,11 @@ namespace ScyllaDB.Alternator
         public TlsConfigBuilder withVerifyHostname(bool verifyHostname)
         {
             return this.WithVerifyHostname(verifyHostname);
+        }
+
+        public TlsConfigBuilder withTlsSessionResumption(bool enabled)
+        {
+            return this.WithTlsSessionResumption(enabled);
         }
 
         public TlsConfig build()

--- a/UnitTests/ConfigValueObjectUnitTests.cs
+++ b/UnitTests/ConfigValueObjectUnitTests.cs
@@ -70,6 +70,7 @@ namespace ScyllaDB.Alternator
                 .withCaCertPath("/tmp/ca.pem")
                 .withClientCertificate("/tmp/client.crt", "/tmp/client.key")
                 .withTrustSystemCaCerts(false)
+                .withTlsSessionResumption(false)
                 .build();
 
             Assert.That(tls.getCustomCaCertPaths(), Is.EqualTo(new[] { "/tmp/ca.pem" }));
@@ -77,8 +78,11 @@ namespace ScyllaDB.Alternator
             Assert.That(tls.isTrustSystemCaCerts(), Is.False);
             Assert.That(tls.isTrustAllCertificates(), Is.False);
             Assert.That(tls.isVerifyHostname(), Is.True);
+            Assert.That(tls.isTlsSessionResumptionEnabled(), Is.False);
             Assert.That(TlsConfig.trustAll().isTrustAllCertificates(), Is.True);
+            Assert.That(TlsConfig.trustAll().isTlsSessionResumptionEnabled(), Is.True);
             Assert.That(TlsConfig.systemDefault().isTrustSystemCaCerts(), Is.True);
+            Assert.That(TlsConfig.systemDefault().isTlsSessionResumptionEnabled(), Is.True);
         }
 
         [Test]

--- a/UnitTests/RequestPipelineUnitTests.cs
+++ b/UnitTests/RequestPipelineUnitTests.cs
@@ -47,6 +47,29 @@ namespace ScyllaDB.Alternator
         }
 
         [Test]
+        public void AlternatorHttpClientFactoryAppliesTlsSessionResumptionSettingTest()
+        {
+            var defaultConfig = AlternatorConfig.builder()
+                .withTlsConfig(TlsConfig.systemDefault())
+                .build();
+            using var defaultHandler = CreateAlternatorSocketsHttpHandler(defaultConfig, _ => { });
+            Assert.That(defaultHandler.SslOptions.AllowTlsResume, Is.True);
+
+            var disabledTlsConfig = TlsConfig.builder()
+                .withTlsSessionResumption(false)
+                .build();
+            var disabledConfig = AlternatorConfig.builder()
+                .withTlsConfig(disabledTlsConfig)
+                .build();
+            using var disabledHandler = CreateAlternatorSocketsHttpHandler(disabledConfig, _ => { });
+            Assert.That(disabledHandler.SslOptions.AllowTlsResume, Is.False);
+
+            var exception = Assert.Throws<NotSupportedException>(() =>
+                CreateAlternatorHttpClientHandler(disabledTlsConfig, 10, _ => { }));
+            Assert.That(exception!.Message, Does.Contain("SocketsHttpHandler"));
+        }
+
+        [Test]
         public void AlternatorHttpClientFactoryRejectsSystemTrustedCertificateWithHostnameMismatchTest()
         {
             using var certificate = LoadSystemTrustedCertificate();
@@ -407,7 +430,16 @@ namespace ScyllaDB.Alternator
                 "CreateHandler",
                 System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
             Assert.That(method, Is.Not.Null);
-            var value = method!.Invoke(null, new object?[] { tlsConfig, maxConnections, customizer });
+            object? value;
+            try
+            {
+                value = method!.Invoke(null, new object?[] { tlsConfig, maxConnections, customizer });
+            }
+            catch (System.Reflection.TargetInvocationException exception) when (exception.InnerException != null)
+            {
+                throw exception.InnerException;
+            }
+
             Assert.That(value, Is.Not.Null);
             return (HttpClientHandler)value!;
         }


### PR DESCRIPTION
## Summary

- Add a `TlsConfig` option to keep TLS session resumption enabled by default and allow callers to disable it.
- Wire the option into the default `SocketsHttpHandler` via `SslOptions.AllowTlsResume`.
- Fail fast when disabling TLS session resumption with the legacy `HttpClientHandler` path, because .NET does not expose a supported switch there.
- Document the default TLS ticket/session resumption behavior and the .NET limitation around portable ticket cache size and timeout controls.

Fixes #4.

## Tests

- `dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj --filter "Category=Unit" --logger:"console;verbosity=minimal"`
- `dotnet format --verify-no-changes --severity warn --verbosity diagnostic ScyllaDB.Alternator.csproj`
- `dotnet build ScyllaDB.Alternator.csproj --configuration Release --verbosity minimal`
- `dotnet build UnitTests/ScyllaDB.Alternator.Test.csproj --configuration Release --verbosity minimal`