### PR TITLE
Add custom header optimization hook

### DIFF
--- a/AlternatorConfig.cs
+++ b/AlternatorConfig.cs
@@ -79,6 +79,8 @@ namespace ScyllaDB.Alternator
             int minCompressionSizeBytes,
             bool optimizeHeaders,
             ISet<string>? headersWhitelist,
+            bool headersWhitelistWasSet,
+            Func<AlternatorConfig, IEnumerable<string>>? customOptimizeHeaders,
             bool userAgentEnabled,
             bool authenticationEnabled,
             KeyRouteAffinityConfig? keyRouteAffinityConfig,
@@ -100,7 +102,9 @@ namespace ScyllaDB.Alternator
             this.OptimizeHeaders = optimizeHeaders;
             this.UserAgentEnabled = userAgentEnabled;
             this.AuthenticationEnabled = authenticationEnabled;
-            this.HeadersWhitelist = this.CreateHeadersWhitelist(headersWhitelist);
+            this.HeadersWhitelistWasSet = headersWhitelistWasSet;
+            this.CustomOptimizeHeaders = customOptimizeHeaders;
+            this.HeadersWhitelist = this.GetRequiredHeaders();
             this.KeyRouteAffinityConfig = keyRouteAffinityConfig;
             this.ActiveRefreshIntervalMs = activeRefreshIntervalMs > 0 ? activeRefreshIntervalMs : DefaultActiveRefreshIntervalMs;
             this.IdleRefreshIntervalMs = idleRefreshIntervalMs > 0 ? idleRefreshIntervalMs : DefaultIdleRefreshIntervalMs;
@@ -110,6 +114,7 @@ namespace ScyllaDB.Alternator
             this.ConnectionAcquisitionTimeoutMs = connectionAcquisitionTimeoutMs;
             this.ConnectionTimeoutMs = connectionTimeoutMs;
             this.TlsConfig = tlsConfig;
+            this.HeadersWhitelist = this.CreateHeadersWhitelist(headersWhitelist, customOptimizeHeaders);
         }
 
         public IReadOnlyList<string> SeedHosts { get; }
@@ -151,6 +156,10 @@ namespace ScyllaDB.Alternator
         public TlsConfig TlsConfig { get; }
 
         public IReadOnlySet<string> RequiredHeaders => this.GetRequiredHeaders();
+
+        internal bool HeadersWhitelistWasSet { get; }
+
+        internal Func<AlternatorConfig, IEnumerable<string>>? CustomOptimizeHeaders { get; }
 
         public static AlternatorConfigBuilder Builder()
         {
@@ -292,14 +301,56 @@ namespace ScyllaDB.Alternator
             return new ReadOnlySet<string>(headers, StringComparer.OrdinalIgnoreCase);
         }
 
-        private IReadOnlySet<string> CreateHeadersWhitelist(ISet<string>? headersWhitelist)
+        internal AlternatorConfigBuilder CopyHeaderOptimizationTo(AlternatorConfigBuilder builder)
+        {
+            if (this.CustomOptimizeHeaders != null)
+            {
+                builder.WithCustomOptimizeHeaders(this.CustomOptimizeHeaders)
+                    .WithOptimizeHeaders(this.OptimizeHeaders);
+                return builder;
+            }
+
+            if (this.HeadersWhitelistWasSet)
+            {
+                builder.WithHeadersWhitelist(this.HeadersWhitelist);
+            }
+
+            return builder;
+        }
+
+        private IReadOnlySet<string> CreateHeadersWhitelist(
+            ISet<string>? headersWhitelist,
+            Func<AlternatorConfig, IEnumerable<string>>? customOptimizeHeaders)
         {
             if (headersWhitelist != null)
             {
                 return CreateReadOnlyHeaderSet(headersWhitelist);
             }
 
+            if (customOptimizeHeaders != null)
+            {
+                var headers = customOptimizeHeaders(this);
+                if (headers == null)
+                {
+                    throw new ArgumentException("Custom header optimizer cannot return null.", nameof(customOptimizeHeaders));
+                }
+
+                var optimized = CreateReadOnlyHeaderSet(headers);
+                this.ValidateRequiredHeaders(optimized, "Custom header optimizer is missing required headers: ");
+                return optimized;
+            }
+
             return this.GetRequiredHeaders();
+        }
+
+        private void ValidateRequiredHeaders(IEnumerable<string> headers, string messagePrefix)
+        {
+            var missing = new HashSet<string>(this.GetRequiredHeaders(), StringComparer.OrdinalIgnoreCase);
+            missing.ExceptWith(headers);
+            if (missing.Count != 0)
+            {
+                throw new ArgumentException(messagePrefix + string.Join(", ", missing));
+            }
         }
     }
 }

--- a/AlternatorConfigBuilder.cs
+++ b/AlternatorConfigBuilder.cs
@@ -20,6 +20,7 @@ namespace ScyllaDB.Alternator
         private bool optimizeHeaders;
         private ISet<string>? headersWhitelist;
         private bool headersWhitelistWasSet;
+        private Func<AlternatorConfig, IEnumerable<string>>? customOptimizeHeaders;
         private bool userAgentEnabled = true;
         private bool authenticationEnabledValue = true;
         private KeyRouteAffinityConfig? keyRouteAffinityConfig;
@@ -134,6 +135,16 @@ namespace ScyllaDB.Alternator
                 ? new HashSet<string>(headers, StringComparer.OrdinalIgnoreCase)
                 : null;
             this.headersWhitelistWasSet = true;
+            this.customOptimizeHeaders = null;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithCustomOptimizeHeaders(Func<AlternatorConfig, IEnumerable<string>> customOptimizeHeaders)
+        {
+            this.customOptimizeHeaders = customOptimizeHeaders ?? throw new ArgumentNullException(nameof(customOptimizeHeaders));
+            this.headersWhitelist = null;
+            this.headersWhitelistWasSet = false;
+            this.optimizeHeaders = true;
             return this;
         }
 
@@ -277,6 +288,11 @@ namespace ScyllaDB.Alternator
             return this.WithHeadersWhitelist(headers);
         }
 
+        public AlternatorConfigBuilder withCustomOptimizeHeaders(Func<AlternatorConfig, IEnumerable<string>> customOptimizeHeaders)
+        {
+            return this.WithCustomOptimizeHeaders(customOptimizeHeaders);
+        }
+
         public AlternatorConfigBuilder withUserAgentEnabled(bool userAgentEnabled)
         {
             return this.WithUserAgentEnabled(userAgentEnabled);
@@ -404,6 +420,8 @@ namespace ScyllaDB.Alternator
                 this.minCompressionSizeBytes,
                 this.optimizeHeaders,
                 this.headersWhitelist,
+                this.headersWhitelistWasSet,
+                this.customOptimizeHeaders,
                 this.userAgentEnabled,
                 this.authenticationEnabledValue,
                 this.keyRouteAffinityConfig,

--- a/AlternatorDynamoDBClientBuilder.cs
+++ b/AlternatorDynamoDBClientBuilder.cs
@@ -289,6 +289,12 @@ namespace ScyllaDB.Alternator
             return this;
         }
 
+        public AlternatorDynamoDBClientBuilder WithCustomOptimizeHeaders(Func<AlternatorConfig, IEnumerable<string>> customOptimizeHeaders)
+        {
+            this.configBuilder.WithCustomOptimizeHeaders(customOptimizeHeaders);
+            return this;
+        }
+
         public AlternatorDynamoDBClientBuilder WithUserAgent(string userAgent)
         {
             this.userAgentTransformer = AlternatorUserAgent.ReplaceWith(userAgent);
@@ -637,6 +643,11 @@ namespace ScyllaDB.Alternator
             return this.WithHeadersWhitelist(headers);
         }
 
+        public AlternatorDynamoDBClientBuilder withCustomOptimizeHeaders(Func<AlternatorConfig, IEnumerable<string>> customOptimizeHeaders)
+        {
+            return this.WithCustomOptimizeHeaders(customOptimizeHeaders);
+        }
+
         public AlternatorDynamoDBClientBuilder withUserAgent(string userAgent)
         {
             return this.WithUserAgent(userAgent);
@@ -820,7 +831,7 @@ namespace ScyllaDB.Alternator
 
         private static AlternatorConfig CreateConfigWithTlsConfig(AlternatorConfig config, TlsConfig tlsConfig)
         {
-            return AlternatorConfig.Builder()
+            var builder = AlternatorConfig.Builder()
                 .WithSeedHosts(config.SeedHosts)
                 .WithScheme(config.Scheme)
                 .WithPort(config.Port)
@@ -828,7 +839,6 @@ namespace ScyllaDB.Alternator
                 .WithCompressionAlgorithm(config.CompressionAlgorithm)
                 .WithMinCompressionSizeBytes(config.MinCompressionSizeBytes)
                 .WithOptimizeHeaders(config.OptimizeHeaders)
-                .WithHeadersWhitelist(config.HeadersWhitelist)
                 .WithUserAgentEnabled(config.UserAgentEnabled)
                 .WithAuthenticationEnabled(config.AuthenticationEnabled)
                 .WithTlsConfig(tlsConfig)
@@ -839,8 +849,10 @@ namespace ScyllaDB.Alternator
                 .WithConnectionMaxIdleTimeMs(config.ConnectionMaxIdleTimeMs)
                 .WithConnectionTimeToLiveMs(config.ConnectionTimeToLiveMs)
                 .WithConnectionAcquisitionTimeoutMs(config.ConnectionAcquisitionTimeoutMs)
-                .WithConnectionTimeoutMs(config.ConnectionTimeoutMs)
-                .Build();
+                .WithConnectionTimeoutMs(config.ConnectionTimeoutMs);
+
+            config.CopyHeaderOptimizationTo(builder);
+            return builder.Build();
         }
 
         private static List<string> NormalizeInitialSeedHosts(IEnumerable<string> seedHosts, string paramName)
@@ -1040,7 +1052,6 @@ namespace ScyllaDB.Alternator
                 .WithCompressionAlgorithm(config.CompressionAlgorithm)
                 .WithMinCompressionSizeBytes(config.MinCompressionSizeBytes)
                 .WithOptimizeHeaders(config.OptimizeHeaders)
-                .WithHeadersWhitelist(config.HeadersWhitelist)
                 .WithUserAgentEnabled(config.UserAgentEnabled)
                 .WithAuthenticationEnabled(config.AuthenticationEnabled)
                 .WithTlsConfig(config.TlsConfig)
@@ -1052,6 +1063,7 @@ namespace ScyllaDB.Alternator
                 .WithConnectionTimeToLiveMs(config.ConnectionTimeToLiveMs)
                 .WithConnectionAcquisitionTimeoutMs(config.ConnectionAcquisitionTimeoutMs)
                 .WithConnectionTimeoutMs(config.ConnectionTimeoutMs);
+            config.CopyHeaderOptimizationTo(this.configBuilder);
         }
 
         private void ApplyLegacyRoutingScope()

--- a/AlternatorLiveNodes.cs
+++ b/AlternatorLiveNodes.cs
@@ -492,11 +492,7 @@ namespace ScyllaDB.Alternator
                 .WithConnectionAcquisitionTimeoutMs(config.ConnectionAcquisitionTimeoutMs)
                 .WithConnectionTimeoutMs(config.ConnectionTimeoutMs);
 
-            if (!new HashSet<string>(config.HeadersWhitelist, StringComparer.OrdinalIgnoreCase).SetEquals(config.RequiredHeaders))
-            {
-                builder.WithHeadersWhitelist(config.HeadersWhitelist);
-            }
-
+            config.CopyHeaderOptimizationTo(builder);
             return builder.Build();
         }
 

--- a/HelperOptions.cs
+++ b/HelperOptions.cs
@@ -73,6 +73,8 @@ namespace ScyllaDB.Alternator
 
         public ISet<string>? HeadersWhitelist { get; set; }
 
+        public Func<AlternatorConfig, IEnumerable<string>>? CustomOptimizeHeaders { get; set; }
+
         public bool AuthenticationEnabled { get; set; } = true;
 
         public KeyRouteAffinityConfig? KeyRouteAffinityConfig { get; set; }
@@ -92,7 +94,12 @@ namespace ScyllaDB.Alternator
                 .WithIdleRefreshIntervalMs(this.IdleRefreshIntervalMs)
                 .WithTlsConfig(this.TlsConfig);
 
-            if (this.HeadersWhitelist != null)
+            if (this.CustomOptimizeHeaders != null)
+            {
+                builder.WithCustomOptimizeHeaders(this.CustomOptimizeHeaders)
+                    .WithOptimizeHeaders(this.OptimizeHeaders);
+            }
+            else if (this.HeadersWhitelist != null)
             {
                 builder.WithHeadersWhitelist(this.HeadersWhitelist);
             }

--- a/HelperOptionsBuilder.cs
+++ b/HelperOptionsBuilder.cs
@@ -184,6 +184,15 @@ namespace ScyllaDB.Alternator
             }
 
             this.options.HeadersWhitelist = new HashSet<string>(headers, StringComparer.OrdinalIgnoreCase);
+            this.options.CustomOptimizeHeaders = null;
+            return this;
+        }
+
+        public HelperOptionsBuilder WithCustomOptimizeHeaders(Func<AlternatorConfig, IEnumerable<string>> customOptimizeHeaders)
+        {
+            this.options.CustomOptimizeHeaders = customOptimizeHeaders ?? throw new ArgumentNullException(nameof(customOptimizeHeaders));
+            this.options.HeadersWhitelist = null;
+            this.options.OptimizeHeaders = true;
             return this;
         }
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,24 @@ AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
     .build();
 ```
 
-Header optimization filters outgoing HTTP headers to the configured whitelist.
+Header optimization filters outgoing HTTP headers to an allow-list. If no
+allow-list is supplied, the client computes one from the effective Alternator
+configuration. The computed list keeps the required transport headers and adds
+authentication, request compression, and User-Agent headers when those features
+are enabled.
+
+```csharp
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .credentialsProvider(credentials)
+    .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+    .withOptimizeHeaders(true)
+    .build();
+```
+
+Use a static whitelist when the exact header set should not change after it is
+configured. Static whitelists are validated against the required headers for the
+effective configuration.
 
 ```csharp
 var configBuilder = AlternatorConfig.builder()
@@ -255,6 +272,19 @@ AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
     .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
     .withOptimizeHeaders(true)
     .withHeadersWhitelist(headers)
+    .build();
+```
+
+Use a custom optimizer when the allow-list should be computed from the final
+configuration.
+
+```csharp
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .credentialsProvider(credentials)
+    .withOptimizeHeaders(true)
+    .withCustomOptimizeHeaders(config =>
+        config.getRequiredHeaders().Concat(new[] { "X-Custom-Trace" }))
     .build();
 ```
 

--- a/UnitTests/ClientBuilderUnitTests.cs
+++ b/UnitTests/ClientBuilderUnitTests.cs
@@ -302,9 +302,11 @@ namespace ScyllaDB.Alternator
         [Test]
         public void AlternatorDynamoDBClientBuilderCopiesAlternatorConfigHeadersWhitelistLikeJavaTest()
         {
-            var config = AlternatorConfig.builder()
+            var configBuilder = AlternatorConfig.builder()
                 .withSeedNode("http://127.0.0.1:8080")
-                .withCompressionAlgorithm(RequestCompressionAlgorithm.NONE)
+                .withCompressionAlgorithm(RequestCompressionAlgorithm.NONE);
+            var config = configBuilder
+                .withHeadersWhitelist(configBuilder.getRequiredHeaders())
                 .build();
 
             var builder = AlternatorDynamoDBClient.builder()
@@ -316,6 +318,25 @@ namespace ScyllaDB.Alternator
 
             var exception = Assert.Throws<ArgumentException>(() => builder.buildWithAlternatorAPI());
             Assert.That(exception!.Message, Does.Contain("Content-Encoding"));
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderRecomputesDefaultHeadersWhitelistTest()
+        {
+            var config = AlternatorConfig.builder()
+                .withSeedNode("http://127.0.0.1:8080")
+                .withCompressionAlgorithm(RequestCompressionAlgorithm.NONE)
+                .build();
+
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .withAlternatorConfig(config)
+                .endpointOverride("http://127.0.0.1:8080")
+                .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+
+            Assert.That(wrapper.Config.HeadersWhitelist, Does.Contain("Content-Encoding"));
         }
 
         [Test]
@@ -569,6 +590,28 @@ namespace ScyllaDB.Alternator
             Assert.That(wrapper.Config.AuthenticationEnabled, Is.False);
             Assert.That(wrapper.Config.HeadersWhitelist, Does.Contain("Content-Encoding"));
             Assert.That(wrapper.Config.HeadersWhitelist, Does.Not.Contain("Authorization"));
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderSupportsCustomHeaderOptimizerTest()
+        {
+            var calledWithAuthentication = false;
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .credentialsProvider(new BasicAWSCredentials("user", "password"))
+                .withCustomOptimizeHeaders(config =>
+                {
+                    calledWithAuthentication = config.AuthenticationEnabled;
+                    return config.RequiredHeaders.Concat(new[] { "X-Custom-Trace" });
+                })
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+
+            Assert.That(calledWithAuthentication, Is.True);
+            Assert.That(wrapper.Config.OptimizeHeaders, Is.True);
+            Assert.That(wrapper.Config.HeadersWhitelist, Does.Contain("Authorization"));
+            Assert.That(wrapper.Config.HeadersWhitelist, Does.Contain("X-Custom-Trace"));
         }
 
         [Test]

--- a/UnitTests/ConfigValueObjectUnitTests.cs
+++ b/UnitTests/ConfigValueObjectUnitTests.cs
@@ -137,5 +137,69 @@ namespace ScyllaDB.Alternator
                 .withHeadersWhitelist(new[] { "Host" })
                 .build());
         }
+
+        [Test]
+        public void AlternatorConfigBuilderComputesOptimizedHeadersFromEffectiveConfigTest()
+        {
+            var minimal = AlternatorConfig.builder()
+                .withAuthenticationEnabled(false)
+                .withUserAgentEnabled(false)
+                .build();
+
+            Assert.That(minimal.HeadersWhitelist, Is.EquivalentTo(AlternatorConfig.BaseRequiredHeaders));
+            Assert.That(minimal.HeadersWhitelist, Does.Not.Contain("Authorization"));
+            Assert.That(minimal.HeadersWhitelist, Does.Not.Contain("Content-Encoding"));
+            Assert.That(minimal.HeadersWhitelist, Does.Not.Contain("User-Agent"));
+
+            var enabled = AlternatorConfig.builder()
+                .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+                .withAuthenticationEnabled(true)
+                .withUserAgentEnabled(true)
+                .build();
+
+            Assert.That(enabled.HeadersWhitelist, Does.Contain("Authorization"));
+            Assert.That(enabled.HeadersWhitelist, Does.Contain("X-Amz-Date"));
+            Assert.That(enabled.HeadersWhitelist, Does.Contain("Content-Encoding"));
+            Assert.That(enabled.HeadersWhitelist, Does.Contain("User-Agent"));
+        }
+
+        [Test]
+        public void AlternatorConfigBuilderSupportsCustomHeaderOptimizerTest()
+        {
+            var calledWithEffectiveConfig = false;
+            var config = AlternatorConfig.builder()
+                .withCompressionAlgorithm(RequestCompressionAlgorithm.GZIP)
+                .withCustomOptimizeHeaders(effectiveConfig =>
+                {
+                    calledWithEffectiveConfig = effectiveConfig.CompressionAlgorithm == RequestCompressionAlgorithm.Gzip
+                        && effectiveConfig.AuthenticationEnabled
+                        && effectiveConfig.UserAgentEnabled;
+                    return effectiveConfig.RequiredHeaders.Concat(new[] { "X-Custom-Trace" });
+                })
+                .build();
+
+            Assert.That(calledWithEffectiveConfig, Is.True);
+            Assert.That(config.OptimizeHeaders, Is.True);
+            Assert.That(config.HeadersWhitelist, Does.Contain("X-Custom-Trace"));
+            Assert.That(config.HeadersWhitelist, Is.SupersetOf(config.RequiredHeaders));
+            Assert.That(AlternatorConfig.builder().withCustomOptimizeHeaders(effectiveConfig => effectiveConfig.RequiredHeaders), Is.Not.Null);
+        }
+
+        [Test]
+        public void AlternatorConfigBuilderValidatesCustomHeaderOptimizerTest()
+        {
+            Assert.Throws<ArgumentNullException>(() => AlternatorConfig.builder()
+                .withCustomOptimizeHeaders(null!));
+
+            var missingRequired = Assert.Throws<ArgumentException>(() => AlternatorConfig.builder()
+                .withCustomOptimizeHeaders(_ => new[] { "Host" })
+                .build());
+            Assert.That(missingRequired!.Message, Does.Contain("Custom header optimizer is missing required headers"));
+
+            var nullHeaders = Assert.Throws<ArgumentException>(() => AlternatorConfig.builder()
+                .withCustomOptimizeHeaders(_ => null!)
+                .build());
+            Assert.That(nullHeaders!.Message, Does.Contain("Custom header optimizer cannot return null"));
+        }
     }
 }

--- a/UnitTests/HelperOptionsBuilderUnitTests.cs
+++ b/UnitTests/HelperOptionsBuilderUnitTests.cs
@@ -78,5 +78,24 @@ namespace ScyllaDB.Alternator
 
             Assert.That(helper, Is.Not.Null);
         }
+
+        [Test]
+        [Category("Unit")]
+        public void HelperOptionsBuilderSupportsCustomHeaderOptimizerTest()
+        {
+            var options = HelperOptionsBuilder.Create()
+                .WithInitialNodeUri(new Uri("http://127.0.0.1:8080"))
+                .WithCustomOptimizeHeaders(config => config.RequiredHeaders.Concat(new[] { "X-Helper-Trace" }))
+                .WithoutValidation()
+                .WithDeferredStart()
+                .Build();
+
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .WithOptions(options)
+                .buildWithAlternatorAPI();
+
+            Assert.That(wrapper.Config.OptimizeHeaders, Is.True);
+            Assert.That(wrapper.Config.HeadersWhitelist, Does.Contain("X-Helper-Trace"));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `WithCustomOptimizeHeaders(...)` for computed header allow-lists across config, client builder, and helper options
- preserve static `WithHeadersWhitelist(...)` validation while keeping default allow-lists computed from the effective config
- carry header optimization mode through config copy paths and document static vs computed behavior

## Tests
- `dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj --no-restore`
- `dotnet build ScyllaDB.Alternator.sln --no-restore`