### PR TITLE
Document request compression behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,13 @@ disable TLS resumption.
 ## Compression and Header Optimization
 
 Request compression is installed in the AWS SDK runtime pipeline before request signing.
+`RequestCompressionAlgorithm.GZIP` enables gzip request-body compression. `NONE`
+or `null` leaves request bodies uncompressed. `withMinCompressionSizeBytes(...)`
+sets the minimum request body size; bodies at or above the threshold are
+compressed, and bodies below the threshold are sent as-is. For seekable streams,
+the remaining stream length is used. Non-seekable streams are treated as
+compressible because their length cannot be checked without consuming the body.
+Requests that already include `Content-Encoding: gzip` are not recompressed.
 
 ```csharp
 AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()

--- a/UnitTests/RequestPipelineUnitTests.cs
+++ b/UnitTests/RequestPipelineUnitTests.cs
@@ -298,16 +298,20 @@ namespace ScyllaDB.Alternator
             var emptyContent = CreateDefaultRequest(Array.Empty<byte>());
             var bodyless = CreateDefaultRequest();
             var alreadyCompressed = CreateDefaultRequest(new byte[10]);
+            var alreadyCompressedCaseInsensitive = CreateDefaultRequest(new byte[10]);
             alreadyCompressed.Headers["Content-Encoding"] = "br, gzip";
+            alreadyCompressedCaseInsensitive.Headers["Content-Encoding"] = "GZip";
 
             Assert.DoesNotThrow(() => InvokeCompressRequest(zeroThresholdHandler, null));
             InvokeCompressRequest(zeroThresholdHandler, emptyContent);
             InvokeCompressRequest(zeroThresholdHandler, bodyless);
             InvokeCompressRequest(zeroThresholdHandler, alreadyCompressed);
+            InvokeCompressRequest(zeroThresholdHandler, alreadyCompressedCaseInsensitive);
 
             Assert.That(emptyContent.CompressionAlgorithm, Is.EqualTo(CompressionEncodingAlgorithm.gzip));
             Assert.That(bodyless.CompressionAlgorithm, Is.Not.EqualTo(CompressionEncodingAlgorithm.gzip));
             Assert.That(alreadyCompressed.CompressionAlgorithm, Is.Not.EqualTo(CompressionEncodingAlgorithm.gzip));
+            Assert.That(alreadyCompressedCaseInsensitive.CompressionAlgorithm, Is.Not.EqualTo(CompressionEncodingAlgorithm.gzip));
         }
 
         [Test]
@@ -326,6 +330,18 @@ namespace ScyllaDB.Alternator
 
             Assert.That(belowThreshold.CompressionAlgorithm, Is.Not.EqualTo(CompressionEncodingAlgorithm.gzip));
             Assert.That(atThreshold.CompressionAlgorithm, Is.EqualTo(CompressionEncodingAlgorithm.gzip));
+        }
+
+        [Test]
+        public void GzipRequestPipelineHandlerCompressesUnseekableStreamsTest()
+        {
+            var handler = new GzipRequestPipelineHandler(1024);
+            using var stream = new UnseekableMemoryStream(new byte[8]);
+            var request = CreateDefaultRequest(contentStream: stream);
+
+            InvokeCompressRequest(handler, request);
+
+            Assert.That(request.CompressionAlgorithm, Is.EqualTo(CompressionEncodingAlgorithm.gzip));
         }
 
         private static (string DirectoryPath, string CertificatePath, string PrivateKeyPath) CreateTemporaryClientCertificateFiles()
@@ -503,6 +519,16 @@ namespace ScyllaDB.Alternator
             Assert.That(method, Is.Not.Null);
             return (request, headers, transformer, appendDefaultToken) =>
                 method!.Invoke(null, new object?[] { request, headers, transformer, appendDefaultToken });
+        }
+
+        private sealed class UnseekableMemoryStream : MemoryStream
+        {
+            internal UnseekableMemoryStream(byte[] buffer)
+                : base(buffer)
+            {
+            }
+
+            public override bool CanSeek => false;
         }
 
         private sealed class CapturingHttpMessageHandler : HttpMessageHandler


### PR DESCRIPTION
## Summary
- document gzip request compression threshold and recompression behavior
- add coverage for case-insensitive existing gzip content encoding
- add coverage for non-seekable request streams

## Tests
- `dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj --no-restore`
- `dotnet build ScyllaDB.Alternator.sln --no-restore`