### PR TITLE
Add response compression support

### DIFF
--- a/AlternatorConfig.cs
+++ b/AlternatorConfig.cs
@@ -37,6 +37,13 @@ namespace ScyllaDB.Alternator
         public const long RECOMMENDED_PARTITION_KEY_DISCOVERY_COOLDOWN_MS = RecommendedPartitionKeyDiscoveryCooldownMs;
 #pragma warning restore SA1310, IDE1006
 
+        public static readonly IReadOnlyList<ResponseCompressionAlgorithm> DefaultResponseCompressionAlgorithms =
+            NormalizeResponseCompressionAlgorithms(new[]
+            {
+                ResponseCompressionAlgorithm.Gzip,
+                ResponseCompressionAlgorithm.Deflate,
+            });
+
         public static readonly IReadOnlySet<string> BaseRequiredHeaders = CreateReadOnlyHeaderSet(new[]
         {
             "Host",
@@ -77,6 +84,7 @@ namespace ScyllaDB.Alternator
             RoutingScope routingScope,
             RequestCompressionAlgorithm compressionAlgorithm,
             int minCompressionSizeBytes,
+            IEnumerable<ResponseCompressionAlgorithm> responseCompressionAlgorithms,
             bool optimizeHeaders,
             ISet<string>? headersWhitelist,
             bool headersWhitelistWasSet,
@@ -99,6 +107,7 @@ namespace ScyllaDB.Alternator
             this.RoutingScope = routingScope;
             this.CompressionAlgorithm = compressionAlgorithm;
             this.MinCompressionSizeBytes = minCompressionSizeBytes >= 0 ? minCompressionSizeBytes : DefaultMinCompressionSizeBytes;
+            this.ResponseCompressionAlgorithms = NormalizeResponseCompressionAlgorithms(responseCompressionAlgorithms);
             this.OptimizeHeaders = optimizeHeaders;
             this.UserAgentEnabled = userAgentEnabled;
             this.AuthenticationEnabled = authenticationEnabled;
@@ -128,6 +137,8 @@ namespace ScyllaDB.Alternator
         public RequestCompressionAlgorithm CompressionAlgorithm { get; }
 
         public int MinCompressionSizeBytes { get; }
+
+        public IReadOnlyList<ResponseCompressionAlgorithm> ResponseCompressionAlgorithms { get; }
 
         public bool OptimizeHeaders { get; }
 
@@ -225,6 +236,11 @@ namespace ScyllaDB.Alternator
             return this.MinCompressionSizeBytes;
         }
 
+        public IReadOnlyList<ResponseCompressionAlgorithm> getResponseCompressionAlgorithms()
+        {
+            return this.ResponseCompressionAlgorithms;
+        }
+
         public bool isOptimizeHeaders()
         {
             return this.OptimizeHeaders;
@@ -299,6 +315,38 @@ namespace ScyllaDB.Alternator
         internal static ReadOnlySet<string> CreateReadOnlyHeaderSet(IEnumerable<string> headers)
         {
             return new ReadOnlySet<string>(headers, StringComparer.OrdinalIgnoreCase);
+        }
+
+        internal static IReadOnlyList<ResponseCompressionAlgorithm> NormalizeResponseCompressionAlgorithms(
+            IEnumerable<ResponseCompressionAlgorithm>? algorithms)
+        {
+            if (algorithms == null)
+            {
+                throw new ArgumentNullException(nameof(algorithms));
+            }
+
+            var normalized = new List<ResponseCompressionAlgorithm>();
+            var seen = new HashSet<ResponseCompressionAlgorithm>();
+            foreach (var algorithm in algorithms)
+            {
+                switch (algorithm)
+                {
+                    case ResponseCompressionAlgorithm.Gzip:
+                    case ResponseCompressionAlgorithm.Deflate:
+                        if (seen.Add(algorithm))
+                        {
+                            normalized.Add(algorithm);
+                        }
+
+                        break;
+                    default:
+                        throw new ArgumentException(
+                            "Unsupported response compression algorithm: " + algorithm,
+                            nameof(algorithms));
+                }
+            }
+
+            return normalized.AsReadOnly();
         }
 
         internal AlternatorConfigBuilder CopyHeaderOptimizationTo(AlternatorConfigBuilder builder)

--- a/AlternatorConfigBuilder.cs
+++ b/AlternatorConfigBuilder.cs
@@ -17,6 +17,9 @@ namespace ScyllaDB.Alternator
         private RoutingScope? routingScope;
         private RequestCompressionAlgorithm compressionAlgorithm = RequestCompressionAlgorithm.None;
         private int minCompressionSizeBytes = AlternatorConfig.DefaultMinCompressionSizeBytes;
+        private IReadOnlyList<ResponseCompressionAlgorithm> responseCompressionAlgorithms =
+            AlternatorConfig.DefaultResponseCompressionAlgorithms;
+
         private bool optimizeHeaders;
         private ISet<string>? headersWhitelist;
         private bool headersWhitelistWasSet;
@@ -120,6 +123,23 @@ namespace ScyllaDB.Alternator
         public AlternatorConfigBuilder WithMinCompressionSizeBytes(int minCompressionSizeBytes)
         {
             this.minCompressionSizeBytes = minCompressionSizeBytes;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithResponseCompression(params ResponseCompressionAlgorithm[] algorithms)
+        {
+            return this.WithResponseCompression((IEnumerable<ResponseCompressionAlgorithm>)algorithms);
+        }
+
+        public AlternatorConfigBuilder WithResponseCompression(IEnumerable<ResponseCompressionAlgorithm> algorithms)
+        {
+            this.responseCompressionAlgorithms = AlternatorConfig.NormalizeResponseCompressionAlgorithms(algorithms);
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithoutResponseCompression()
+        {
+            this.responseCompressionAlgorithms = Array.Empty<ResponseCompressionAlgorithm>();
             return this;
         }
 
@@ -278,6 +298,21 @@ namespace ScyllaDB.Alternator
             return this.WithMinCompressionSizeBytes(minCompressionSizeBytes);
         }
 
+        public AlternatorConfigBuilder withResponseCompression(params ResponseCompressionAlgorithm[] algorithms)
+        {
+            return this.WithResponseCompression(algorithms);
+        }
+
+        public AlternatorConfigBuilder withResponseCompression(IEnumerable<ResponseCompressionAlgorithm> algorithms)
+        {
+            return this.WithResponseCompression(algorithms);
+        }
+
+        public AlternatorConfigBuilder withoutResponseCompression()
+        {
+            return this.WithoutResponseCompression();
+        }
+
         public AlternatorConfigBuilder withOptimizeHeaders(bool optimizeHeaders)
         {
             return this.WithOptimizeHeaders(optimizeHeaders);
@@ -418,6 +453,7 @@ namespace ScyllaDB.Alternator
                 this.routingScope ?? ClusterScope.Create(),
                 this.compressionAlgorithm,
                 this.minCompressionSizeBytes,
+                this.responseCompressionAlgorithms,
                 this.optimizeHeaders,
                 this.headersWhitelist,
                 this.headersWhitelistWasSet,

--- a/AlternatorDynamoDBClientBuilder.cs
+++ b/AlternatorDynamoDBClientBuilder.cs
@@ -277,6 +277,24 @@ namespace ScyllaDB.Alternator
             return this;
         }
 
+        public AlternatorDynamoDBClientBuilder WithResponseCompression(params ResponseCompressionAlgorithm[] algorithms)
+        {
+            this.configBuilder.WithResponseCompression(algorithms);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithResponseCompression(IEnumerable<ResponseCompressionAlgorithm> algorithms)
+        {
+            this.configBuilder.WithResponseCompression(algorithms);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithoutResponseCompression()
+        {
+            this.configBuilder.WithoutResponseCompression();
+            return this;
+        }
+
         public AlternatorDynamoDBClientBuilder WithOptimizeHeaders(bool optimizeHeaders)
         {
             this.configBuilder.WithOptimizeHeaders(optimizeHeaders);
@@ -633,6 +651,21 @@ namespace ScyllaDB.Alternator
             return this.WithMinCompressionSizeBytes(minCompressionSizeBytes);
         }
 
+        public AlternatorDynamoDBClientBuilder withResponseCompression(params ResponseCompressionAlgorithm[] algorithms)
+        {
+            return this.WithResponseCompression(algorithms);
+        }
+
+        public AlternatorDynamoDBClientBuilder withResponseCompression(IEnumerable<ResponseCompressionAlgorithm> algorithms)
+        {
+            return this.WithResponseCompression(algorithms);
+        }
+
+        public AlternatorDynamoDBClientBuilder withoutResponseCompression()
+        {
+            return this.WithoutResponseCompression();
+        }
+
         public AlternatorDynamoDBClientBuilder withOptimizeHeaders(bool optimizeHeaders)
         {
             return this.WithOptimizeHeaders(optimizeHeaders);
@@ -838,6 +871,7 @@ namespace ScyllaDB.Alternator
                 .WithRoutingScope(config.RoutingScope)
                 .WithCompressionAlgorithm(config.CompressionAlgorithm)
                 .WithMinCompressionSizeBytes(config.MinCompressionSizeBytes)
+                .WithResponseCompression(config.ResponseCompressionAlgorithms)
                 .WithOptimizeHeaders(config.OptimizeHeaders)
                 .WithUserAgentEnabled(config.UserAgentEnabled)
                 .WithAuthenticationEnabled(config.AuthenticationEnabled)
@@ -1051,6 +1085,7 @@ namespace ScyllaDB.Alternator
                 .WithRoutingScope(config.RoutingScope)
                 .WithCompressionAlgorithm(config.CompressionAlgorithm)
                 .WithMinCompressionSizeBytes(config.MinCompressionSizeBytes)
+                .WithResponseCompression(config.ResponseCompressionAlgorithms)
                 .WithOptimizeHeaders(config.OptimizeHeaders)
                 .WithUserAgentEnabled(config.UserAgentEnabled)
                 .WithAuthenticationEnabled(config.AuthenticationEnabled)

--- a/AlternatorHttpClientFactory.cs
+++ b/AlternatorHttpClientFactory.cs
@@ -37,6 +37,11 @@ namespace ScyllaDB.Alternator
                 handler = new HeadersFilteringHttpMessageHandler(handler, this.config.HeadersWhitelist);
             }
 
+            if (this.config.ResponseCompressionAlgorithms.Count > 0)
+            {
+                handler = new ResponseCompressionHttpMessageHandler(handler, this.config.ResponseCompressionAlgorithms);
+            }
+
             return new HttpClient(handler);
         }
 

--- a/AlternatorLiveNodes.cs
+++ b/AlternatorLiveNodes.cs
@@ -479,6 +479,7 @@ namespace ScyllaDB.Alternator
                 .WithRoutingScope(config.RoutingScope)
                 .WithCompressionAlgorithm(config.CompressionAlgorithm)
                 .WithMinCompressionSizeBytes(config.MinCompressionSizeBytes)
+                .WithResponseCompression(config.ResponseCompressionAlgorithms)
                 .WithOptimizeHeaders(config.OptimizeHeaders)
                 .WithUserAgentEnabled(config.UserAgentEnabled)
                 .WithAuthenticationEnabled(config.AuthenticationEnabled)

--- a/HelperOptions.cs
+++ b/HelperOptions.cs
@@ -69,6 +69,9 @@ namespace ScyllaDB.Alternator
 
         public int MinCompressionSizeBytes { get; set; } = AlternatorConfig.DefaultMinCompressionSizeBytes;
 
+        public IReadOnlyList<ResponseCompressionAlgorithm> ResponseCompressionAlgorithms { get; set; } =
+            AlternatorConfig.DefaultResponseCompressionAlgorithms;
+
         public bool OptimizeHeaders { get; set; }
 
         public ISet<string>? HeadersWhitelist { get; set; }
@@ -87,6 +90,7 @@ namespace ScyllaDB.Alternator
                 .WithPort(this.Port)
                 .WithCompressionAlgorithm(this.CompressionAlgorithm)
                 .WithMinCompressionSizeBytes(this.MinCompressionSizeBytes)
+                .WithResponseCompression(this.ResponseCompressionAlgorithms)
                 .WithOptimizeHeaders(this.OptimizeHeaders)
                 .WithAuthenticationEnabled(this.AuthenticationEnabled)
                 .WithKeyRouteAffinity(this.KeyRouteAffinityConfig)

--- a/HelperOptionsBuilder.cs
+++ b/HelperOptionsBuilder.cs
@@ -170,6 +170,23 @@ namespace ScyllaDB.Alternator
             return this;
         }
 
+        public HelperOptionsBuilder WithResponseCompression(params ResponseCompressionAlgorithm[] algorithms)
+        {
+            return this.WithResponseCompression((IEnumerable<ResponseCompressionAlgorithm>)algorithms);
+        }
+
+        public HelperOptionsBuilder WithResponseCompression(IEnumerable<ResponseCompressionAlgorithm> algorithms)
+        {
+            this.options.ResponseCompressionAlgorithms = AlternatorConfig.NormalizeResponseCompressionAlgorithms(algorithms);
+            return this;
+        }
+
+        public HelperOptionsBuilder WithoutResponseCompression()
+        {
+            this.options.ResponseCompressionAlgorithms = Array.Empty<ResponseCompressionAlgorithm>();
+            return this;
+        }
+
         public HelperOptionsBuilder WithOptimizeHeaders(bool optimizeHeaders)
         {
             this.options.OptimizeHeaders = optimizeHeaders;

--- a/README.md
+++ b/README.md
@@ -247,6 +247,27 @@ AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
     .build();
 ```
 
+Response compression is enabled by default for `gzip` and `deflate`. The client
+sends `Accept-Encoding: gzip, deflate` when no request header is already set, and
+decodes supported compressed response bodies before the AWS SDK reads them.
+Unsupported response encodings are left unchanged.
+
+```csharp
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .credentialsProvider(credentials)
+    .withResponseCompression(ResponseCompressionAlgorithm.GZIP)
+    .build();
+```
+
+```csharp
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .credentialsProvider(credentials)
+    .withoutResponseCompression()
+    .build();
+```
+
 Header optimization filters outgoing HTTP headers to an allow-list. If no
 allow-list is supplied, the client computes one from the effective Alternator
 configuration. The computed list keeps the required transport headers and adds

--- a/ResponseCompressionAlgorithm.cs
+++ b/ResponseCompressionAlgorithm.cs
@@ -1,0 +1,17 @@
+// <copyright file="ResponseCompressionAlgorithm.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    public enum ResponseCompressionAlgorithm
+    {
+        Gzip = 0,
+        Deflate = 1,
+
+#pragma warning disable SA1300, IDE1006
+        GZIP = Gzip,
+        DEFLATE = Deflate,
+#pragma warning restore SA1300, IDE1006
+    }
+}

--- a/ResponseCompressionHttpMessageHandler.cs
+++ b/ResponseCompressionHttpMessageHandler.cs
@@ -1,0 +1,126 @@
+// <copyright file="ResponseCompressionHttpMessageHandler.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    using System.IO.Compression;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+
+    public sealed class ResponseCompressionHttpMessageHandler : DelegatingHandler
+    {
+        private const string AcceptEncodingHeader = "Accept-Encoding";
+        private const string ContentEncodingHeader = "Content-Encoding";
+        private const string ContentLengthHeader = "Content-Length";
+        private readonly IReadOnlyList<ResponseCompressionAlgorithm> algorithms;
+        private readonly string acceptEncodingValue;
+
+        public ResponseCompressionHttpMessageHandler(
+            HttpMessageHandler innerHandler,
+            IEnumerable<ResponseCompressionAlgorithm> algorithms)
+            : base(innerHandler ?? throw new ArgumentNullException(nameof(innerHandler)))
+        {
+            this.algorithms = AlternatorConfig.NormalizeResponseCompressionAlgorithms(algorithms);
+            this.acceptEncodingValue = string.Join(", ", this.algorithms.Select(ToContentEncoding));
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            this.ApplyAcceptEncoding(request);
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            if (response.Content == null || this.algorithms.Count == 0)
+            {
+                return response;
+            }
+
+            var contentEncoding = GetSingleContentEncoding(response.Content.Headers);
+            var decoder = this.CreateDecoder(contentEncoding);
+            if (decoder == null)
+            {
+                return response;
+            }
+
+            var originalContent = response.Content;
+            var originalStream = await originalContent.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            var decodedContent = new StreamContent(decoder(originalStream));
+            CopyContentHeaders(originalContent.Headers, decodedContent.Headers);
+            response.Content = decodedContent;
+            return response;
+        }
+
+        private static string ToContentEncoding(ResponseCompressionAlgorithm algorithm)
+        {
+            return algorithm switch
+            {
+                ResponseCompressionAlgorithm.Gzip => "gzip",
+                ResponseCompressionAlgorithm.Deflate => "deflate",
+                _ => throw new ArgumentException("Unsupported response compression algorithm: " + algorithm, nameof(algorithm)),
+            };
+        }
+
+        private static string? GetSingleContentEncoding(HttpContentHeaders headers)
+        {
+            return headers.ContentEncoding.Count == 1
+                ? headers.ContentEncoding.First()
+                : null;
+        }
+
+        private static void CopyContentHeaders(HttpContentHeaders source, HttpContentHeaders destination)
+        {
+            foreach (var header in source)
+            {
+                if (string.Equals(header.Key, ContentEncodingHeader, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(header.Key, ContentLengthHeader, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                destination.TryAddWithoutValidation(header.Key, header.Value);
+            }
+        }
+
+        private void ApplyAcceptEncoding(HttpRequestMessage request)
+        {
+            if (this.algorithms.Count == 0)
+            {
+                return;
+            }
+
+            if (request.Headers.TryGetValues(AcceptEncodingHeader, out var values))
+            {
+                var existing = string.Join(",", values).Trim();
+                if (!string.Equals(existing, "identity", StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+
+                request.Headers.Remove(AcceptEncodingHeader);
+            }
+
+            request.Headers.TryAddWithoutValidation(AcceptEncodingHeader, this.acceptEncodingValue);
+        }
+
+        private Func<Stream, Stream>? CreateDecoder(string? contentEncoding)
+        {
+            if (contentEncoding == null)
+            {
+                return null;
+            }
+
+            if (string.Equals(contentEncoding, "gzip", StringComparison.OrdinalIgnoreCase)
+                && this.algorithms.Contains(ResponseCompressionAlgorithm.Gzip))
+            {
+                return stream => new GZipStream(stream, CompressionMode.Decompress);
+            }
+
+            if (string.Equals(contentEncoding, "deflate", StringComparison.OrdinalIgnoreCase)
+                && this.algorithms.Contains(ResponseCompressionAlgorithm.Deflate))
+            {
+                return stream => new DeflateStream(stream, CompressionMode.Decompress);
+            }
+
+            return null;
+        }
+    }
+}

--- a/UnitTests/ClientBuilderUnitTests.cs
+++ b/UnitTests/ClientBuilderUnitTests.cs
@@ -593,6 +593,26 @@ namespace ScyllaDB.Alternator
         }
 
         [Test]
+        public void AlternatorDynamoDBClientBuilderSupportsResponseCompressionConfigurationTest()
+        {
+            using var deflateWrapper = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .withResponseCompression(ResponseCompressionAlgorithm.DEFLATE)
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+            using var disabledWrapper = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8081")
+                .withoutResponseCompression()
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+
+            Assert.That(deflateWrapper.Config.ResponseCompressionAlgorithms, Is.EqualTo(new[] { ResponseCompressionAlgorithm.Deflate }));
+            Assert.That(disabledWrapper.Config.ResponseCompressionAlgorithms, Is.Empty);
+        }
+
+        [Test]
         public void AlternatorDynamoDBClientBuilderSupportsCustomHeaderOptimizerTest()
         {
             var calledWithAuthentication = false;

--- a/UnitTests/ConfigValueObjectUnitTests.cs
+++ b/UnitTests/ConfigValueObjectUnitTests.cs
@@ -201,5 +201,35 @@ namespace ScyllaDB.Alternator
                 .build());
             Assert.That(nullHeaders!.Message, Does.Contain("Custom header optimizer cannot return null"));
         }
+
+        [Test]
+        public void AlternatorConfigBuilderConfiguresResponseCompressionTest()
+        {
+            var defaultConfig = AlternatorConfig.builder().build();
+            Assert.That(
+                defaultConfig.getResponseCompressionAlgorithms(),
+                Is.EqualTo(new[] { ResponseCompressionAlgorithm.Gzip, ResponseCompressionAlgorithm.Deflate }));
+
+            var deflateOnly = AlternatorConfig.builder()
+                .withResponseCompression(ResponseCompressionAlgorithm.DEFLATE)
+                .build();
+            Assert.That(deflateOnly.ResponseCompressionAlgorithms, Is.EqualTo(new[] { ResponseCompressionAlgorithm.Deflate }));
+
+            var deduplicated = AlternatorConfig.builder()
+                .withResponseCompression(ResponseCompressionAlgorithm.GZIP, ResponseCompressionAlgorithm.Gzip)
+                .build();
+            Assert.That(deduplicated.ResponseCompressionAlgorithms, Is.EqualTo(new[] { ResponseCompressionAlgorithm.Gzip }));
+
+            var disabled = AlternatorConfig.builder()
+                .withoutResponseCompression()
+                .build();
+            Assert.That(disabled.ResponseCompressionAlgorithms, Is.Empty);
+
+            Assert.Throws<ArgumentNullException>(() => AlternatorConfig.builder()
+                .withResponseCompression((IEnumerable<ResponseCompressionAlgorithm>)null!));
+            Assert.Throws<ArgumentException>(() => AlternatorConfig.builder()
+                .withResponseCompression((ResponseCompressionAlgorithm)999)
+                .build());
+        }
     }
 }

--- a/UnitTests/HelperOptionsBuilderUnitTests.cs
+++ b/UnitTests/HelperOptionsBuilderUnitTests.cs
@@ -97,5 +97,33 @@ namespace ScyllaDB.Alternator
             Assert.That(wrapper.Config.OptimizeHeaders, Is.True);
             Assert.That(wrapper.Config.HeadersWhitelist, Does.Contain("X-Helper-Trace"));
         }
+
+        [Test]
+        [Category("Unit")]
+        public void HelperOptionsBuilderSupportsResponseCompressionConfigurationTest()
+        {
+            var options = HelperOptionsBuilder.Create()
+                .WithInitialNodeUri(new Uri("http://127.0.0.1:8080"))
+                .WithResponseCompression(ResponseCompressionAlgorithm.GZIP)
+                .WithoutValidation()
+                .WithDeferredStart()
+                .Build();
+            var disabledOptions = HelperOptionsBuilder.Create()
+                .WithInitialNodeUri(new Uri("http://127.0.0.1:8081"))
+                .WithoutResponseCompression()
+                .WithoutValidation()
+                .WithDeferredStart()
+                .Build();
+
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .WithOptions(options)
+                .buildWithAlternatorAPI();
+            using var disabledWrapper = AlternatorDynamoDBClient.builder()
+                .WithOptions(disabledOptions)
+                .buildWithAlternatorAPI();
+
+            Assert.That(wrapper.Config.ResponseCompressionAlgorithms, Is.EqualTo(new[] { ResponseCompressionAlgorithm.Gzip }));
+            Assert.That(disabledWrapper.Config.ResponseCompressionAlgorithms, Is.Empty);
+        }
     }
 }

--- a/UnitTests/RequestPipelineUnitTests.cs
+++ b/UnitTests/RequestPipelineUnitTests.cs
@@ -4,6 +4,7 @@
 
 namespace ScyllaDB.Alternator
 {
+    using System.IO.Compression;
     using System.Net.Security;
     using System.Security.Cryptography;
     using System.Security.Cryptography.X509Certificates;
@@ -96,6 +97,89 @@ namespace ScyllaDB.Alternator
             {
                 File.Delete(caPath);
             }
+        }
+
+        [Test]
+        public async Task ResponseCompressionHttpMessageHandlerDecodesGzipResponsesTest()
+        {
+            var responseBody = "{\"ok\":true}";
+            var compressedBody = Compress(responseBody, ResponseCompressionAlgorithm.Gzip);
+            var innerHandler = new CapturingHttpMessageHandler(_ => CreateCompressedResponse(
+                compressedBody,
+                "gzip"));
+            using var handler = new ResponseCompressionHttpMessageHandler(
+                innerHandler,
+                AlternatorConfig.DefaultResponseCompressionAlgorithms);
+            using var client = new HttpClient(handler);
+
+            using var response = await client.GetAsync("http://127.0.0.1/");
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.That(innerHandler.Request, Is.Not.Null);
+            Assert.That(
+                string.Join(", ", innerHandler.Request!.Headers.GetValues("Accept-Encoding")),
+                Is.EqualTo("gzip, deflate"));
+            Assert.That(body, Is.EqualTo(responseBody));
+            Assert.That(response.Content.Headers.ContentEncoding, Is.Empty);
+        }
+
+        [Test]
+        public async Task ResponseCompressionHttpMessageHandlerDecodesDeflateResponsesTest()
+        {
+            var responseBody = "{\"ok\":true}";
+            var compressedBody = Compress(responseBody, ResponseCompressionAlgorithm.Deflate);
+            var innerHandler = new CapturingHttpMessageHandler(_ => CreateCompressedResponse(
+                compressedBody,
+                "deflate"));
+            using var handler = new ResponseCompressionHttpMessageHandler(
+                innerHandler,
+                AlternatorConfig.DefaultResponseCompressionAlgorithms);
+            using var client = new HttpClient(handler);
+
+            using var response = await client.GetAsync("http://127.0.0.1/");
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.That(body, Is.EqualTo(responseBody));
+            Assert.That(response.Content.Headers.ContentEncoding, Is.Empty);
+        }
+
+        [Test]
+        public async Task ResponseCompressionHttpMessageHandlerCanBeDisabledTest()
+        {
+            var innerHandler = new CapturingHttpMessageHandler(_ => new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent("plain"),
+            });
+            using var handler = new ResponseCompressionHttpMessageHandler(
+                innerHandler,
+                Array.Empty<ResponseCompressionAlgorithm>());
+            using var client = new HttpClient(handler);
+
+            using var response = await client.GetAsync("http://127.0.0.1/");
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.That(innerHandler.Request, Is.Not.Null);
+            Assert.That(innerHandler.Request!.Headers.Contains("Accept-Encoding"), Is.False);
+            Assert.That(body, Is.EqualTo("plain"));
+        }
+
+        [Test]
+        public async Task ResponseCompressionHttpMessageHandlerPassesUnsupportedEncodingsThroughTest()
+        {
+            var originalBody = System.Text.Encoding.UTF8.GetBytes("encoded");
+            var innerHandler = new CapturingHttpMessageHandler(_ => CreateCompressedResponse(
+                originalBody,
+                "br"));
+            using var handler = new ResponseCompressionHttpMessageHandler(
+                innerHandler,
+                AlternatorConfig.DefaultResponseCompressionAlgorithms);
+            using var client = new HttpClient(handler);
+
+            using var response = await client.GetAsync("http://127.0.0.1/");
+            var body = await response.Content.ReadAsByteArrayAsync();
+
+            Assert.That(body, Is.EqualTo(originalBody));
+            Assert.That(response.Content.Headers.ContentEncoding, Is.EqualTo(new[] { "br" }));
         }
 
         [Test]
@@ -372,6 +456,39 @@ namespace ScyllaDB.Alternator
             };
         }
 
+        private static HttpResponseMessage CreateCompressedResponse(byte[] content, string contentEncoding)
+        {
+            var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(content),
+            };
+            response.Content.Headers.ContentEncoding.Add(contentEncoding);
+            response.Content.Headers.ContentLength = content.Length;
+            return response;
+        }
+
+        private static byte[] Compress(string value, ResponseCompressionAlgorithm algorithm)
+        {
+            var data = System.Text.Encoding.UTF8.GetBytes(value);
+            using var output = new MemoryStream();
+            using (var compressed = CreateCompressionStream(output, algorithm))
+            {
+                compressed.Write(data, 0, data.Length);
+            }
+
+            return output.ToArray();
+        }
+
+        private static Stream CreateCompressionStream(Stream output, ResponseCompressionAlgorithm algorithm)
+        {
+            return algorithm switch
+            {
+                ResponseCompressionAlgorithm.Gzip => new GZipStream(output, CompressionLevel.Fastest, true),
+                ResponseCompressionAlgorithm.Deflate => new DeflateStream(output, CompressionLevel.Fastest, true),
+                _ => throw new ArgumentException("Unsupported response compression algorithm: " + algorithm, nameof(algorithm)),
+            };
+        }
+
         private static X509Certificate2 LoadSystemTrustedCertificate()
         {
             var certificate = TryLoadSystemTrustedCertificate(StoreLocation.CurrentUser)
@@ -533,6 +650,18 @@ namespace ScyllaDB.Alternator
 
         private sealed class CapturingHttpMessageHandler : HttpMessageHandler
         {
+            private readonly Func<HttpRequestMessage, HttpResponseMessage> responseFactory;
+
+            internal CapturingHttpMessageHandler()
+                : this(_ => new HttpResponseMessage(System.Net.HttpStatusCode.OK))
+            {
+            }
+
+            internal CapturingHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+            {
+                this.responseFactory = responseFactory;
+            }
+
             internal HttpRequestMessage? Request { get; private set; }
 
             internal bool Disposed { get; private set; }
@@ -540,7 +669,7 @@ namespace ScyllaDB.Alternator
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 this.Request = request;
-                return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+                return Task.FromResult(this.responseFactory(request));
             }
 
             protected override void Dispose(bool disposing)


### PR DESCRIPTION
## Summary
- add configurable response compression for gzip and deflate
- request supported response encodings and decode supported compressed bodies in the HTTP pipeline
- add disable/configuration APIs across config, client builder, and helper options
- document defaults and unsupported encoding behavior

## Tests
- `dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj --no-restore`
- `dotnet build ScyllaDB.Alternator.sln --no-restore`