### PR TITLE
Add in-memory TLS configuration

### DIFF
--- a/AlternatorHttpClientFactory.cs
+++ b/AlternatorHttpClientFactory.cs
@@ -82,13 +82,13 @@ namespace ScyllaDB.Alternator
             if (tlsConfig.hasClientCertificate())
             {
                 handler.ClientCertificateOptions = ClientCertificateOption.Manual;
-                handler.ClientCertificates.Add(LoadClientCertificate(tlsConfig));
+                handler.ClientCertificates.AddRange(LoadClientCertificates(tlsConfig));
             }
 
-            if (tlsConfig.TrustAllCertificates || tlsConfig.CustomCaCertPaths.Count > 0 || !tlsConfig.VerifyHostname)
+            if (NeedsCustomCertificateValidation(tlsConfig))
             {
-                handler.ServerCertificateCustomValidationCallback = (_, certificate, chain, sslPolicyErrors) =>
-                    ValidateCertificate(tlsConfig, certificate, chain, sslPolicyErrors);
+                handler.ServerCertificateCustomValidationCallback = (request, certificate, chain, sslPolicyErrors) =>
+                    ValidateCertificate(tlsConfig, request, certificate, chain, sslPolicyErrors);
             }
 
             configureHandler?.Invoke(handler);
@@ -114,16 +114,13 @@ namespace ScyllaDB.Alternator
 
             if (config.TlsConfig.hasClientCertificate())
             {
-                handler.SslOptions.ClientCertificates = new X509CertificateCollection
-                {
-                    LoadClientCertificate(config.TlsConfig),
-                };
+                handler.SslOptions.ClientCertificates = LoadClientCertificates(config.TlsConfig);
             }
 
             if (NeedsCustomCertificateValidation(config.TlsConfig))
             {
-                handler.SslOptions.RemoteCertificateValidationCallback = (_, certificate, chain, sslPolicyErrors) =>
-                    ValidateCertificate(config.TlsConfig, certificate, chain, sslPolicyErrors);
+                handler.SslOptions.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) =>
+                    ValidateCertificate(config.TlsConfig, sender, certificate, chain, sslPolicyErrors);
             }
 
             configureHandler?.Invoke(handler);
@@ -132,14 +129,29 @@ namespace ScyllaDB.Alternator
 
         private static bool NeedsCustomCertificateValidation(TlsConfig tlsConfig)
         {
-            return tlsConfig.TrustAllCertificates || tlsConfig.CustomCaCertPaths.Count > 0 || !tlsConfig.VerifyHostname;
+            return tlsConfig.CertificateValidationCallback != null
+                || tlsConfig.TrustAllCertificates
+                || tlsConfig.CustomCaCertPaths.Count > 0
+                || tlsConfig.CustomCaCertificates.Count > 0
+                || !tlsConfig.VerifyHostname;
         }
 
-        private static X509Certificate2 LoadClientCertificate(TlsConfig tlsConfig)
+        private static X509CertificateCollection LoadClientCertificates(TlsConfig tlsConfig)
         {
-            return X509Certificate2.CreateFromPemFile(
-                tlsConfig.ClientCertificatePath!,
-                tlsConfig.ClientPrivateKeyPath!);
+            var certificates = new X509CertificateCollection();
+            foreach (var certificate in tlsConfig.ClientCertificates)
+            {
+                certificates.Add(certificate);
+            }
+
+            if (tlsConfig.ClientCertificatePath != null && tlsConfig.ClientPrivateKeyPath != null)
+            {
+                certificates.Add(X509Certificate2.CreateFromPemFile(
+                    tlsConfig.ClientCertificatePath,
+                    tlsConfig.ClientPrivateKeyPath));
+            }
+
+            return certificates;
         }
 
         private static TimeSpan ToTimeout(long timeoutMs)
@@ -155,6 +167,16 @@ namespace ScyllaDB.Alternator
             X509Chain? chain,
             SslPolicyErrors sslPolicyErrors)
         {
+            return ValidateCertificate(tlsConfig, null, certificate, chain, sslPolicyErrors);
+        }
+
+        private static bool ValidateCertificate(
+            TlsConfig tlsConfig,
+            object? sender,
+            X509Certificate? certificate,
+            X509Chain? chain,
+            SslPolicyErrors sslPolicyErrors)
+        {
             var certificate2 = certificate as X509Certificate2;
             X509Certificate2? convertedCertificate = null;
             if (certificate != null && certificate2 == null)
@@ -165,7 +187,7 @@ namespace ScyllaDB.Alternator
 
             try
             {
-                return ValidateCertificate(tlsConfig, certificate2, chain, sslPolicyErrors);
+                return ValidateCertificate(tlsConfig, sender, certificate2, chain, sslPolicyErrors);
             }
             finally
             {
@@ -179,6 +201,21 @@ namespace ScyllaDB.Alternator
             X509Chain? chain,
             SslPolicyErrors sslPolicyErrors)
         {
+            return ValidateCertificate(tlsConfig, null, certificate, chain, sslPolicyErrors);
+        }
+
+        private static bool ValidateCertificate(
+            TlsConfig tlsConfig,
+            object? sender,
+            X509Certificate2? certificate,
+            X509Chain? chain,
+            SslPolicyErrors sslPolicyErrors)
+        {
+            if (tlsConfig.CertificateValidationCallback != null)
+            {
+                return tlsConfig.CertificateValidationCallback(sender ?? tlsConfig, certificate, chain, sslPolicyErrors);
+            }
+
             if (tlsConfig.TrustAllCertificates)
             {
                 return true;
@@ -202,7 +239,7 @@ namespace ScyllaDB.Alternator
                 return false;
             }
 
-            if (certificate == null || tlsConfig.CustomCaCertPaths.Count == 0)
+            if (certificate == null || (tlsConfig.CustomCaCertPaths.Count == 0 && tlsConfig.CustomCaCertificates.Count == 0))
             {
                 return false;
             }
@@ -219,6 +256,11 @@ namespace ScyllaDB.Alternator
             foreach (var certPath in tlsConfig.CustomCaCertPaths)
             {
                 customChain.ChainPolicy.CustomTrustStore.Add(new X509Certificate2(certPath));
+            }
+
+            foreach (var customCaCertificate in tlsConfig.CustomCaCertificates)
+            {
+                customChain.ChainPolicy.CustomTrustStore.Add(customCaCertificate);
             }
 
             var chainValid = customChain.Build(certificate);

--- a/README.md
+++ b/README.md
@@ -204,6 +204,28 @@ AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
     .build();
 ```
 
+Preloaded certificates can be supplied when certificate material is already
+available in memory:
+
+```csharp
+var tls = TlsConfig.builder()
+    .withCaCertificate(caCertificate)
+    .withClientCertificate(clientCertificate)
+    .withTrustSystemCaCerts(false)
+    .build();
+```
+
+A custom server certificate validation callback can be configured without
+replacing the HTTP client factory:
+
+```csharp
+var tls = TlsConfig.builder()
+    .withTrustSystemCaCerts(false)
+    .withCertificateValidationCallback((sender, certificate, chain, errors) =>
+        errors == SslPolicyErrors.None)
+    .build();
+```
+
 Convenience factories:
 
 ```csharp
@@ -226,6 +248,10 @@ portable session ticket cache size or timeout controls through `HttpClient`.
 Use the default `SocketsHttpHandler` transport for this setting; the legacy
 `withHttpClientHandlerCustomizer(...)` path uses platform defaults and cannot
 disable TLS resumption.
+
+The target .NET `HttpClient` APIs also do not expose a per-client TLS key-log
+writer. Runtime- or platform-level TLS key logging, when available, must be
+configured outside this library.
 
 ## Compression and Header Optimization
 

--- a/TlsConfig.cs
+++ b/TlsConfig.cs
@@ -4,11 +4,17 @@
 
 namespace ScyllaDB.Alternator
 {
+    using System.Net.Security;
+    using System.Security.Cryptography.X509Certificates;
+
     public sealed class TlsConfig
     {
         private static readonly TlsConfig TrustAllInstance = new TlsConfig(
             new List<string>(),
+            new List<X509Certificate2>(),
             null,
+            null,
+            new List<X509Certificate2>(),
             null,
             false,
             true,
@@ -17,7 +23,10 @@ namespace ScyllaDB.Alternator
 
         private static readonly TlsConfig SystemDefaultInstance = new TlsConfig(
             new List<string>(),
+            new List<X509Certificate2>(),
             null,
+            null,
+            new List<X509Certificate2>(),
             null,
             true,
             false,
@@ -26,16 +35,22 @@ namespace ScyllaDB.Alternator
 
         internal TlsConfig(
             IReadOnlyList<string> customCaCertPaths,
+            IReadOnlyList<X509Certificate2> customCaCertificates,
             string? clientCertificatePath,
             string? clientPrivateKeyPath,
+            IReadOnlyList<X509Certificate2> clientCertificates,
+            RemoteCertificateValidationCallback? certificateValidationCallback,
             bool trustSystemCaCerts,
             bool trustAllCertificates,
             bool verifyHostname,
             bool tlsSessionResumptionEnabled)
         {
             this.CustomCaCertPaths = new List<string>(customCaCertPaths ?? Array.Empty<string>()).AsReadOnly();
+            this.CustomCaCertificates = CopyCertificates(customCaCertificates);
             this.ClientCertificatePath = clientCertificatePath;
             this.ClientPrivateKeyPath = clientPrivateKeyPath;
+            this.ClientCertificates = CopyCertificates(clientCertificates);
+            this.CertificateValidationCallback = certificateValidationCallback;
             this.TrustSystemCaCerts = trustSystemCaCerts;
             this.TrustAllCertificates = trustAllCertificates;
             this.VerifyHostname = verifyHostname;
@@ -44,11 +59,18 @@ namespace ScyllaDB.Alternator
 
         public IReadOnlyList<string> CustomCaCertPaths { get; }
 
+        public IReadOnlyList<X509Certificate2> CustomCaCertificates { get; }
+
         public string? ClientCertificatePath { get; }
 
         public string? ClientPrivateKeyPath { get; }
 
-        public bool HasClientCertificate => this.ClientCertificatePath != null && this.ClientPrivateKeyPath != null;
+        public IReadOnlyList<X509Certificate2> ClientCertificates { get; }
+
+        public bool HasClientCertificate =>
+            (this.ClientCertificatePath != null && this.ClientPrivateKeyPath != null) || this.ClientCertificates.Count > 0;
+
+        public RemoteCertificateValidationCallback? CertificateValidationCallback { get; }
 
         public bool TrustSystemCaCerts { get; }
 
@@ -104,6 +126,21 @@ namespace ScyllaDB.Alternator
             return this.ClientPrivateKeyPath;
         }
 
+        public IReadOnlyList<X509Certificate2> getCustomCaCertificates()
+        {
+            return this.CustomCaCertificates;
+        }
+
+        public IReadOnlyList<X509Certificate2> getClientCertificates()
+        {
+            return this.ClientCertificates;
+        }
+
+        public RemoteCertificateValidationCallback? getCertificateValidationCallback()
+        {
+            return this.CertificateValidationCallback;
+        }
+
         public bool hasClientCertificate()
         {
             return this.HasClientCertificate;
@@ -138,10 +175,16 @@ namespace ScyllaDB.Alternator
                 + "["
                 + string.Join(", ", this.CustomCaCertPaths)
                 + "]"
+                + ", customCaCertificates="
+                + this.CustomCaCertificates.Count
                 + ", clientCertificatePath="
                 + (this.ClientCertificatePath ?? "null")
                 + ", clientPrivateKeyPath="
                 + (this.ClientPrivateKeyPath ?? "null")
+                + ", clientCertificates="
+                + this.ClientCertificates.Count
+                + ", certificateValidationCallback="
+                + (this.CertificateValidationCallback == null ? "null" : "configured")
                 + ", trustSystemCaCerts="
                 + this.TrustSystemCaCerts.ToString().ToLowerInvariant()
                 + ", trustAllCertificates="
@@ -161,8 +204,11 @@ namespace ScyllaDB.Alternator
                 && this.VerifyHostname == other.VerifyHostname
                 && this.TlsSessionResumptionEnabled == other.TlsSessionResumptionEnabled
                 && this.CustomCaCertPaths.SequenceEqual(other.CustomCaCertPaths)
+                && CertificatesEqual(this.CustomCaCertificates, other.CustomCaCertificates)
                 && string.Equals(this.ClientCertificatePath, other.ClientCertificatePath, StringComparison.Ordinal)
-                && string.Equals(this.ClientPrivateKeyPath, other.ClientPrivateKeyPath, StringComparison.Ordinal);
+                && string.Equals(this.ClientPrivateKeyPath, other.ClientPrivateKeyPath, StringComparison.Ordinal)
+                && CertificatesEqual(this.ClientCertificates, other.ClientCertificates)
+                && Equals(this.CertificateValidationCallback, other.CertificateValidationCallback);
         }
 
         public override int GetHashCode()
@@ -175,11 +221,42 @@ namespace ScyllaDB.Alternator
 
             hash.Add(this.ClientCertificatePath, StringComparer.Ordinal);
             hash.Add(this.ClientPrivateKeyPath, StringComparer.Ordinal);
+            AddCertificateHashes(hash, this.CustomCaCertificates);
+            AddCertificateHashes(hash, this.ClientCertificates);
+            hash.Add(this.CertificateValidationCallback);
             hash.Add(this.TrustSystemCaCerts);
             hash.Add(this.TrustAllCertificates);
             hash.Add(this.VerifyHostname);
             hash.Add(this.TlsSessionResumptionEnabled);
             return hash.ToHashCode();
+        }
+
+        private static IReadOnlyList<X509Certificate2> CopyCertificates(IEnumerable<X509Certificate2>? certificates)
+        {
+            if (certificates == null)
+            {
+                return Array.Empty<X509Certificate2>();
+            }
+
+            return certificates.Select(certificate => new X509Certificate2(certificate)).ToList().AsReadOnly();
+        }
+
+        private static bool CertificatesEqual(
+            IReadOnlyList<X509Certificate2> left,
+            IReadOnlyList<X509Certificate2> right)
+        {
+            return left.Count == right.Count
+                && left.Zip(right, (leftCertificate, rightCertificate) =>
+                    string.Equals(leftCertificate.Thumbprint, rightCertificate.Thumbprint, StringComparison.OrdinalIgnoreCase))
+                    .All(equal => equal);
+        }
+
+        private static void AddCertificateHashes(HashCode hash, IEnumerable<X509Certificate2> certificates)
+        {
+            foreach (var certificate in certificates)
+            {
+                hash.Add(certificate.Thumbprint, StringComparer.OrdinalIgnoreCase);
+            }
         }
     }
 }

--- a/TlsConfigBuilder.cs
+++ b/TlsConfigBuilder.cs
@@ -4,11 +4,17 @@
 
 namespace ScyllaDB.Alternator
 {
+    using System.Net.Security;
+    using System.Security.Cryptography.X509Certificates;
+
     public sealed class TlsConfigBuilder
     {
         private List<string> customCaCertPaths = new List<string>();
+        private List<X509Certificate2> customCaCertificates = new List<X509Certificate2>();
         private string? clientCertificatePath;
         private string? clientPrivateKeyPath;
+        private List<X509Certificate2> clientCertificates = new List<X509Certificate2>();
+        private RemoteCertificateValidationCallback? certificateValidationCallback;
         private bool trustSystemCaCerts = true;
         private bool trustAllCertificates;
         private bool verifyHostname = true;
@@ -42,6 +48,34 @@ namespace ScyllaDB.Alternator
             return this;
         }
 
+        public TlsConfigBuilder WithCaCertificate(X509Certificate2? certificate)
+        {
+            if (certificate == null)
+            {
+                throw new ArgumentException("CA certificate cannot be null", nameof(certificate));
+            }
+
+            this.customCaCertificates.Add(certificate);
+            return this;
+        }
+
+        public TlsConfigBuilder WithCaCertificates(IEnumerable<X509Certificate2>? certificates)
+        {
+            if (certificates == null)
+            {
+                this.customCaCertificates = new List<X509Certificate2>();
+                return this;
+            }
+
+            this.customCaCertificates = new List<X509Certificate2>();
+            foreach (var certificate in certificates)
+            {
+                this.WithCaCertificate(certificate);
+            }
+
+            return this;
+        }
+
         public TlsConfigBuilder WithClientCertificate(string? certificatePath, string? privateKeyPath)
         {
             if (certificatePath == null)
@@ -56,6 +90,45 @@ namespace ScyllaDB.Alternator
 
             this.clientCertificatePath = certificatePath;
             this.clientPrivateKeyPath = privateKeyPath;
+            return this;
+        }
+
+        public TlsConfigBuilder WithClientCertificate(X509Certificate2? certificate)
+        {
+            if (certificate == null)
+            {
+                throw new ArgumentException("Client certificate cannot be null", nameof(certificate));
+            }
+
+            if (!certificate.HasPrivateKey)
+            {
+                throw new ArgumentException("Client certificate must include a private key", nameof(certificate));
+            }
+
+            this.clientCertificates.Add(certificate);
+            return this;
+        }
+
+        public TlsConfigBuilder WithClientCertificates(IEnumerable<X509Certificate2>? certificates)
+        {
+            if (certificates == null)
+            {
+                this.clientCertificates = new List<X509Certificate2>();
+                return this;
+            }
+
+            this.clientCertificates = new List<X509Certificate2>();
+            foreach (var certificate in certificates)
+            {
+                this.WithClientCertificate(certificate);
+            }
+
+            return this;
+        }
+
+        public TlsConfigBuilder WithCertificateValidationCallback(RemoteCertificateValidationCallback? callback)
+        {
+            this.certificateValidationCallback = callback;
             return this;
         }
 
@@ -85,7 +158,11 @@ namespace ScyllaDB.Alternator
 
         public TlsConfig Build()
         {
-            if (!this.trustAllCertificates && !this.trustSystemCaCerts && this.customCaCertPaths.Count == 0)
+            if (!this.trustAllCertificates
+                && !this.trustSystemCaCerts
+                && this.customCaCertPaths.Count == 0
+                && this.customCaCertificates.Count == 0
+                && this.certificateValidationCallback == null)
             {
                 throw new InvalidOperationException(
                     "Invalid TLS configuration: no trust source configured. Either enable trustSystemCaCerts, add custom CA certificates, or enable trustAllCertificates (for development only).");
@@ -93,8 +170,11 @@ namespace ScyllaDB.Alternator
 
             return new TlsConfig(
                 this.customCaCertPaths.AsReadOnly(),
+                this.customCaCertificates.AsReadOnly(),
                 this.clientCertificatePath,
                 this.clientPrivateKeyPath,
+                this.clientCertificates.AsReadOnly(),
+                this.certificateValidationCallback,
                 this.trustSystemCaCerts,
                 this.trustAllCertificates,
                 this.trustAllCertificates ? false : this.verifyHostname,
@@ -112,9 +192,34 @@ namespace ScyllaDB.Alternator
             return this.WithCaCertPaths(paths);
         }
 
+        public TlsConfigBuilder withCaCertificate(X509Certificate2? certificate)
+        {
+            return this.WithCaCertificate(certificate);
+        }
+
+        public TlsConfigBuilder withCaCertificates(IEnumerable<X509Certificate2>? certificates)
+        {
+            return this.WithCaCertificates(certificates);
+        }
+
         public TlsConfigBuilder withClientCertificate(string? certificatePath, string? privateKeyPath)
         {
             return this.WithClientCertificate(certificatePath, privateKeyPath);
+        }
+
+        public TlsConfigBuilder withClientCertificate(X509Certificate2? certificate)
+        {
+            return this.WithClientCertificate(certificate);
+        }
+
+        public TlsConfigBuilder withClientCertificates(IEnumerable<X509Certificate2>? certificates)
+        {
+            return this.WithClientCertificates(certificates);
+        }
+
+        public TlsConfigBuilder withCertificateValidationCallback(RemoteCertificateValidationCallback? callback)
+        {
+            return this.WithCertificateValidationCallback(callback);
         }
 
         public TlsConfigBuilder withTrustSystemCaCerts(bool trustSystemCaCerts)

--- a/UnitTests/RequestPipelineUnitTests.cs
+++ b/UnitTests/RequestPipelineUnitTests.cs
@@ -48,6 +48,74 @@ namespace ScyllaDB.Alternator
         }
 
         [Test]
+        public void AlternatorHttpClientFactoryAppliesPreloadedClientCertificateToHandlersTest()
+        {
+            using var certificate = CreateSelfSignedCertificate("CN=alternator-client-test", true);
+            var tlsConfig = TlsConfig.builder()
+                .withClientCertificate(certificate)
+                .build();
+
+            using var httpClientHandler = CreateAlternatorHttpClientHandler(tlsConfig, 10, _ => { });
+            Assert.That(httpClientHandler.ClientCertificateOptions, Is.EqualTo(ClientCertificateOption.Manual));
+            Assert.That(httpClientHandler.ClientCertificates, Has.Count.EqualTo(1));
+            Assert.That(((X509Certificate2)httpClientHandler.ClientCertificates[0]).HasPrivateKey, Is.True);
+
+            var alternatorConfig = AlternatorConfig.builder()
+                .withTlsConfig(tlsConfig)
+                .build();
+            using var socketsHttpHandler = CreateAlternatorSocketsHttpHandler(alternatorConfig, _ => { });
+            Assert.That(socketsHttpHandler.SslOptions.ClientCertificates, Is.Not.Null);
+            Assert.That(socketsHttpHandler.SslOptions.ClientCertificates, Has.Count.EqualTo(1));
+            Assert.That(((X509Certificate2)socketsHttpHandler.SslOptions.ClientCertificates![0]).HasPrivateKey, Is.True);
+        }
+
+        [Test]
+        public void AlternatorHttpClientFactoryAcceptsPreloadedCustomCaCertificateTest()
+        {
+            using var caCertificate = CreateSelfSignedCertificate("CN=alternator-ca-test", true);
+            using var serverCertificate = CreateIssuedCertificate("CN=alternator-server-test", caCertificate);
+            using var chain = new X509Chain();
+            var tlsConfig = TlsConfig.builder()
+                .withTrustSystemCaCerts(false)
+                .withCaCertificate(caCertificate)
+                .build();
+
+            var accepted = InvokeValidateCertificate(
+                tlsConfig,
+                serverCertificate,
+                chain,
+                SslPolicyErrors.RemoteCertificateChainErrors);
+
+            Assert.That(accepted, Is.True);
+        }
+
+        [Test]
+        public void AlternatorHttpClientFactoryUsesCustomCertificateValidationCallbackTest()
+        {
+            var callbackCalled = false;
+            using var certificate = CreateSelfSignedCertificate("CN=alternator-callback-test", true);
+            using var chain = new X509Chain();
+            var tlsConfig = TlsConfig.builder()
+                .withTrustSystemCaCerts(false)
+                .withCertificateValidationCallback((_, callbackCertificate, _, sslPolicyErrors) =>
+                {
+                    callbackCalled = ReferenceEquals(certificate, callbackCertificate)
+                        && sslPolicyErrors == SslPolicyErrors.RemoteCertificateChainErrors;
+                    return true;
+                })
+                .build();
+
+            var accepted = InvokeValidateCertificate(
+                tlsConfig,
+                certificate,
+                chain,
+                SslPolicyErrors.RemoteCertificateChainErrors);
+
+            Assert.That(accepted, Is.True);
+            Assert.That(callbackCalled, Is.True);
+        }
+
+        [Test]
         public void AlternatorHttpClientFactoryAppliesTlsSessionResumptionSettingTest()
         {
             var defaultConfig = AlternatorConfig.builder()
@@ -445,6 +513,42 @@ namespace ScyllaDB.Alternator
             File.WriteAllText(certificatePath, certificate.ExportCertificatePem());
             File.WriteAllText(privateKeyPath, rsa.ExportPkcs8PrivateKeyPem());
             return (directory, certificatePath, privateKeyPath);
+        }
+
+        private static X509Certificate2 CreateSelfSignedCertificate(string subjectName, bool certificateAuthority)
+        {
+            using var rsa = RSA.Create(2048);
+            var request = new CertificateRequest(
+                subjectName,
+                rsa,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+            request.CertificateExtensions.Add(new X509BasicConstraintsExtension(certificateAuthority, false, 0, true));
+            request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+            using var certificate = request.CreateSelfSigned(
+                DateTimeOffset.UtcNow.AddMinutes(-1),
+                DateTimeOffset.UtcNow.AddDays(1));
+            return new X509Certificate2(certificate.Export(X509ContentType.Pkcs12));
+        }
+
+        private static X509Certificate2 CreateIssuedCertificate(string subjectName, X509Certificate2 issuer)
+        {
+            using var rsa = RSA.Create(2048);
+            var request = new CertificateRequest(
+                subjectName,
+                rsa,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+            request.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, true));
+            request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+            var serialNumber = RandomNumberGenerator.GetBytes(16);
+            using var certificate = request.Create(
+                issuer,
+                DateTimeOffset.UtcNow.AddMinutes(-1),
+                new DateTimeOffset(issuer.NotAfter).AddMinutes(-1),
+                serialNumber);
+            using var certificateWithPrivateKey = certificate.CopyWithPrivateKey(rsa);
+            return new X509Certificate2(certificateWithPrivateKey.Export(X509ContentType.Pkcs12));
         }
 
         private static DefaultRequest CreateDefaultRequest(byte[] content = null!, Stream? contentStream = null)


### PR DESCRIPTION
## Summary
- add in-memory custom CA certificates and client certificates to TLS config
- add a server certificate validation callback option without replacing the HTTP client factory
- apply preloaded TLS material to both supported HTTP handler paths
- document in-memory TLS configuration and .NET HttpClient TLS limits

## Tests
- `dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj --no-restore`
- `dotnet build ScyllaDB.Alternator.sln --no-restore`