### PR TITLE
Add HTTP connection tuning aliases

### DIFF
--- a/AlternatorConfig.cs
+++ b/AlternatorConfig.cs
@@ -17,6 +17,7 @@ namespace ScyllaDB.Alternator
         public const long DefaultConnectionTimeToLiveMs = 0;
         public const long DefaultConnectionAcquisitionTimeoutMs = 10000;
         public const long DefaultConnectionTimeoutMs = 15000;
+        public const long DefaultHttpClientTimeoutMs = DefaultConnectionTimeoutMs;
         public const int RecommendedPartitionKeyDiscoveryMaxRetries = 3;
         public const long RecommendedPartitionKeyDiscoveryInitialDelayMs = 100;
         public const long RecommendedPartitionKeyDiscoveryMaxDelayMs = 2000;
@@ -31,6 +32,7 @@ namespace ScyllaDB.Alternator
         public const long DEFAULT_CONNECTION_TIME_TO_LIVE_MS = DefaultConnectionTimeToLiveMs;
         public const long DEFAULT_CONNECTION_ACQUISITION_TIMEOUT_MS = DefaultConnectionAcquisitionTimeoutMs;
         public const long DEFAULT_CONNECTION_TIMEOUT_MS = DefaultConnectionTimeoutMs;
+        public const long DEFAULT_HTTP_CLIENT_TIMEOUT_MS = DefaultHttpClientTimeoutMs;
         public const int RECOMMENDED_PARTITION_KEY_DISCOVERY_MAX_RETRIES = RecommendedPartitionKeyDiscoveryMaxRetries;
         public const long RECOMMENDED_PARTITION_KEY_DISCOVERY_INITIAL_DELAY_MS = RecommendedPartitionKeyDiscoveryInitialDelayMs;
         public const long RECOMMENDED_PARTITION_KEY_DISCOVERY_MAX_DELAY_MS = RecommendedPartitionKeyDiscoveryMaxDelayMs;
@@ -99,6 +101,7 @@ namespace ScyllaDB.Alternator
             long connectionTimeToLiveMs,
             long connectionAcquisitionTimeoutMs,
             long connectionTimeoutMs,
+            long httpClientTimeoutMs,
             TlsConfig tlsConfig)
         {
             this.SeedHosts = seedHosts.AsReadOnly();
@@ -122,6 +125,7 @@ namespace ScyllaDB.Alternator
             this.ConnectionTimeToLiveMs = connectionTimeToLiveMs;
             this.ConnectionAcquisitionTimeoutMs = connectionAcquisitionTimeoutMs;
             this.ConnectionTimeoutMs = connectionTimeoutMs;
+            this.HttpClientTimeoutMs = httpClientTimeoutMs;
             this.TlsConfig = tlsConfig;
             this.HeadersWhitelist = this.CreateHeadersWhitelist(headersWhitelist, customOptimizeHeaders);
         }
@@ -163,6 +167,8 @@ namespace ScyllaDB.Alternator
         public long ConnectionAcquisitionTimeoutMs { get; }
 
         public long ConnectionTimeoutMs { get; }
+
+        public long HttpClientTimeoutMs { get; }
 
         public TlsConfig TlsConfig { get; }
 
@@ -304,6 +310,11 @@ namespace ScyllaDB.Alternator
         public long getConnectionTimeoutMs()
         {
             return this.ConnectionTimeoutMs;
+        }
+
+        public long getHttpClientTimeoutMs()
+        {
+            return this.HttpClientTimeoutMs;
         }
 
         public IReadOnlySet<string> getRequiredHeaders()

--- a/AlternatorConfigBuilder.cs
+++ b/AlternatorConfigBuilder.cs
@@ -35,6 +35,7 @@ namespace ScyllaDB.Alternator
         private long connectionTimeToLiveMs = AlternatorConfig.DefaultConnectionTimeToLiveMs;
         private long connectionAcquisitionTimeoutMs = AlternatorConfig.DefaultConnectionAcquisitionTimeoutMs;
         private long connectionTimeoutMs = AlternatorConfig.DefaultConnectionTimeoutMs;
+        private long httpClientTimeoutMs = AlternatorConfig.DefaultHttpClientTimeoutMs;
         private TlsConfig? tlsConfig;
 
         public AlternatorConfigBuilder WithSeedNode(Uri? seedUri)
@@ -216,11 +217,26 @@ namespace ScyllaDB.Alternator
             return this;
         }
 
+        public AlternatorConfigBuilder WithMaxIdleHttpConnections(int maxIdleHttpConnections)
+        {
+            return this.WithMaxConnections(maxIdleHttpConnections);
+        }
+
+        public AlternatorConfigBuilder WithMaxIdleHttpConnectionsPerHost(int maxIdleHttpConnectionsPerHost)
+        {
+            return this.WithMaxConnections(maxIdleHttpConnectionsPerHost);
+        }
+
         public AlternatorConfigBuilder WithConnectionMaxIdleTimeMs(long connectionMaxIdleTimeMs)
         {
             this.connectionMaxIdleTimeMs = connectionMaxIdleTimeMs;
             this.connectionMaxIdleTimeMsSet = true;
             return this;
+        }
+
+        public AlternatorConfigBuilder WithIdleHttpConnectionTimeoutMs(long idleHttpConnectionTimeoutMs)
+        {
+            return this.WithConnectionMaxIdleTimeMs(idleHttpConnectionTimeoutMs);
         }
 
         public AlternatorConfigBuilder WithConnectionTimeToLiveMs(long connectionTimeToLiveMs)
@@ -238,6 +254,13 @@ namespace ScyllaDB.Alternator
         public AlternatorConfigBuilder WithConnectionTimeoutMs(long connectionTimeoutMs)
         {
             this.connectionTimeoutMs = connectionTimeoutMs;
+            this.httpClientTimeoutMs = connectionTimeoutMs;
+            return this;
+        }
+
+        public AlternatorConfigBuilder WithHttpClientTimeoutMs(long httpClientTimeoutMs)
+        {
+            this.httpClientTimeoutMs = httpClientTimeoutMs;
             return this;
         }
 
@@ -383,9 +406,24 @@ namespace ScyllaDB.Alternator
             return this.WithMaxConnections(maxConnections);
         }
 
+        public AlternatorConfigBuilder withMaxIdleHttpConnections(int maxIdleHttpConnections)
+        {
+            return this.WithMaxIdleHttpConnections(maxIdleHttpConnections);
+        }
+
+        public AlternatorConfigBuilder withMaxIdleHttpConnectionsPerHost(int maxIdleHttpConnectionsPerHost)
+        {
+            return this.WithMaxIdleHttpConnectionsPerHost(maxIdleHttpConnectionsPerHost);
+        }
+
         public AlternatorConfigBuilder withConnectionMaxIdleTimeMs(long connectionMaxIdleTimeMs)
         {
             return this.WithConnectionMaxIdleTimeMs(connectionMaxIdleTimeMs);
+        }
+
+        public AlternatorConfigBuilder withIdleHttpConnectionTimeoutMs(long idleHttpConnectionTimeoutMs)
+        {
+            return this.WithIdleHttpConnectionTimeoutMs(idleHttpConnectionTimeoutMs);
         }
 
         public AlternatorConfigBuilder withConnectionTimeToLiveMs(long connectionTimeToLiveMs)
@@ -401,6 +439,11 @@ namespace ScyllaDB.Alternator
         public AlternatorConfigBuilder withConnectionTimeoutMs(long connectionTimeoutMs)
         {
             return this.WithConnectionTimeoutMs(connectionTimeoutMs);
+        }
+
+        public AlternatorConfigBuilder withHttpClientTimeoutMs(long httpClientTimeoutMs)
+        {
+            return this.WithHttpClientTimeoutMs(httpClientTimeoutMs);
         }
 
         public AlternatorConfig build()
@@ -468,6 +511,7 @@ namespace ScyllaDB.Alternator
                 this.connectionTimeToLiveMs,
                 this.connectionAcquisitionTimeoutMs,
                 this.connectionTimeoutMs,
+                this.httpClientTimeoutMs,
                 effectiveTlsConfig);
         }
 
@@ -523,6 +567,13 @@ namespace ScyllaDB.Alternator
                 throw new ArgumentException(
                     "connectionTimeoutMs must be non-negative, but was: " + this.connectionTimeoutMs,
                     nameof(this.connectionTimeoutMs));
+            }
+
+            if (this.httpClientTimeoutMs < 0)
+            {
+                throw new ArgumentException(
+                    "httpClientTimeoutMs must be non-negative, but was: " + this.httpClientTimeoutMs,
+                    nameof(this.httpClientTimeoutMs));
             }
         }
 

--- a/AlternatorDynamoDBClientBuilder.cs
+++ b/AlternatorDynamoDBClientBuilder.cs
@@ -375,9 +375,27 @@ namespace ScyllaDB.Alternator
             return this;
         }
 
+        public AlternatorDynamoDBClientBuilder WithMaxIdleHttpConnections(int maxIdleHttpConnections)
+        {
+            this.configBuilder.WithMaxIdleHttpConnections(maxIdleHttpConnections);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithMaxIdleHttpConnectionsPerHost(int maxIdleHttpConnectionsPerHost)
+        {
+            this.configBuilder.WithMaxIdleHttpConnectionsPerHost(maxIdleHttpConnectionsPerHost);
+            return this;
+        }
+
         public AlternatorDynamoDBClientBuilder WithConnectionMaxIdleTimeMs(long connectionMaxIdleTimeMs)
         {
             this.configBuilder.WithConnectionMaxIdleTimeMs(connectionMaxIdleTimeMs);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithIdleHttpConnectionTimeoutMs(long idleHttpConnectionTimeoutMs)
+        {
+            this.configBuilder.WithIdleHttpConnectionTimeoutMs(idleHttpConnectionTimeoutMs);
             return this;
         }
 
@@ -396,6 +414,12 @@ namespace ScyllaDB.Alternator
         public AlternatorDynamoDBClientBuilder WithConnectionTimeoutMs(long connectionTimeoutMs)
         {
             this.configBuilder.WithConnectionTimeoutMs(connectionTimeoutMs);
+            return this;
+        }
+
+        public AlternatorDynamoDBClientBuilder WithHttpClientTimeoutMs(long httpClientTimeoutMs)
+        {
+            this.configBuilder.WithHttpClientTimeoutMs(httpClientTimeoutMs);
             return this;
         }
 
@@ -731,9 +755,24 @@ namespace ScyllaDB.Alternator
             return this.WithMaxConnections(maxConnections);
         }
 
+        public AlternatorDynamoDBClientBuilder withMaxIdleHttpConnections(int maxIdleHttpConnections)
+        {
+            return this.WithMaxIdleHttpConnections(maxIdleHttpConnections);
+        }
+
+        public AlternatorDynamoDBClientBuilder withMaxIdleHttpConnectionsPerHost(int maxIdleHttpConnectionsPerHost)
+        {
+            return this.WithMaxIdleHttpConnectionsPerHost(maxIdleHttpConnectionsPerHost);
+        }
+
         public AlternatorDynamoDBClientBuilder withConnectionMaxIdleTimeMs(long connectionMaxIdleTimeMs)
         {
             return this.WithConnectionMaxIdleTimeMs(connectionMaxIdleTimeMs);
+        }
+
+        public AlternatorDynamoDBClientBuilder withIdleHttpConnectionTimeoutMs(long idleHttpConnectionTimeoutMs)
+        {
+            return this.WithIdleHttpConnectionTimeoutMs(idleHttpConnectionTimeoutMs);
         }
 
         public AlternatorDynamoDBClientBuilder withConnectionTimeToLiveMs(long connectionTimeToLiveMs)
@@ -749,6 +788,11 @@ namespace ScyllaDB.Alternator
         public AlternatorDynamoDBClientBuilder withConnectionTimeoutMs(long connectionTimeoutMs)
         {
             return this.WithConnectionTimeoutMs(connectionTimeoutMs);
+        }
+
+        public AlternatorDynamoDBClientBuilder withHttpClientTimeoutMs(long httpClientTimeoutMs)
+        {
+            return this.WithHttpClientTimeoutMs(httpClientTimeoutMs);
         }
 
         public AlternatorDynamoDBClientBuilder withDisableCertificateChecks()
@@ -883,7 +927,8 @@ namespace ScyllaDB.Alternator
                 .WithConnectionMaxIdleTimeMs(config.ConnectionMaxIdleTimeMs)
                 .WithConnectionTimeToLiveMs(config.ConnectionTimeToLiveMs)
                 .WithConnectionAcquisitionTimeoutMs(config.ConnectionAcquisitionTimeoutMs)
-                .WithConnectionTimeoutMs(config.ConnectionTimeoutMs);
+                .WithConnectionTimeoutMs(config.ConnectionTimeoutMs)
+                .WithHttpClientTimeoutMs(config.HttpClientTimeoutMs);
 
             config.CopyHeaderOptimizationTo(builder);
             return builder.Build();
@@ -938,9 +983,9 @@ namespace ScyllaDB.Alternator
                     this.options.CancellationToken)
                 : new Helper(alternatorConfig, this.validateOnInitialization, this.startImmediately, this.cancellationToken);
 
-            if (alternatorConfig.ConnectionTimeoutMs > 0)
+            if (alternatorConfig.HttpClientTimeoutMs > 0)
             {
-                dynamoDbConfig.Timeout = TimeSpan.FromMilliseconds(alternatorConfig.ConnectionTimeoutMs);
+                dynamoDbConfig.Timeout = TimeSpan.FromMilliseconds(alternatorConfig.HttpClientTimeoutMs);
             }
 
             dynamoDbConfig.MaxConnectionsPerServer = alternatorConfig.MaxConnections;
@@ -1097,7 +1142,8 @@ namespace ScyllaDB.Alternator
                 .WithConnectionMaxIdleTimeMs(config.ConnectionMaxIdleTimeMs)
                 .WithConnectionTimeToLiveMs(config.ConnectionTimeToLiveMs)
                 .WithConnectionAcquisitionTimeoutMs(config.ConnectionAcquisitionTimeoutMs)
-                .WithConnectionTimeoutMs(config.ConnectionTimeoutMs);
+                .WithConnectionTimeoutMs(config.ConnectionTimeoutMs)
+                .WithHttpClientTimeoutMs(config.HttpClientTimeoutMs);
             config.CopyHeaderOptimizationTo(this.configBuilder);
         }
 

--- a/AlternatorLiveNodes.cs
+++ b/AlternatorLiveNodes.cs
@@ -491,7 +491,8 @@ namespace ScyllaDB.Alternator
                 .WithConnectionMaxIdleTimeMs(config.ConnectionMaxIdleTimeMs)
                 .WithConnectionTimeToLiveMs(config.ConnectionTimeToLiveMs)
                 .WithConnectionAcquisitionTimeoutMs(config.ConnectionAcquisitionTimeoutMs)
-                .WithConnectionTimeoutMs(config.ConnectionTimeoutMs);
+                .WithConnectionTimeoutMs(config.ConnectionTimeoutMs)
+                .WithHttpClientTimeoutMs(config.HttpClientTimeoutMs);
 
             config.CopyHeaderOptimizationTo(builder);
             return builder.Build();

--- a/HelperOptions.cs
+++ b/HelperOptions.cs
@@ -63,6 +63,18 @@ namespace ScyllaDB.Alternator
 
         public long IdleRefreshIntervalMs { get; set; } = AlternatorConfig.DefaultIdleRefreshIntervalMs;
 
+        public int MaxConnections { get; set; } = AlternatorConfig.DefaultMaxConnections;
+
+        public long ConnectionMaxIdleTimeMs { get; set; } = AlternatorConfig.DefaultConnectionMaxIdleTimeMs;
+
+        public long ConnectionTimeToLiveMs { get; set; } = AlternatorConfig.DefaultConnectionTimeToLiveMs;
+
+        public long ConnectionAcquisitionTimeoutMs { get; set; } = AlternatorConfig.DefaultConnectionAcquisitionTimeoutMs;
+
+        public long ConnectionTimeoutMs { get; set; } = AlternatorConfig.DefaultConnectionTimeoutMs;
+
+        public long HttpClientTimeoutMs { get; set; } = AlternatorConfig.DefaultHttpClientTimeoutMs;
+
         public TlsConfig TlsConfig { get; set; } = TlsConfig.TrustAll();
 
         public RequestCompressionAlgorithm CompressionAlgorithm { get; set; } = RequestCompressionAlgorithm.None;
@@ -96,6 +108,12 @@ namespace ScyllaDB.Alternator
                 .WithKeyRouteAffinity(this.KeyRouteAffinityConfig)
                 .WithActiveRefreshIntervalMs(this.ActiveRefreshIntervalMs)
                 .WithIdleRefreshIntervalMs(this.IdleRefreshIntervalMs)
+                .WithMaxConnections(this.MaxConnections)
+                .WithConnectionMaxIdleTimeMs(this.ConnectionMaxIdleTimeMs)
+                .WithConnectionTimeToLiveMs(this.ConnectionTimeToLiveMs)
+                .WithConnectionAcquisitionTimeoutMs(this.ConnectionAcquisitionTimeoutMs)
+                .WithConnectionTimeoutMs(this.ConnectionTimeoutMs)
+                .WithHttpClientTimeoutMs(this.HttpClientTimeoutMs)
                 .WithTlsConfig(this.TlsConfig);
 
             if (this.CustomOptimizeHeaders != null)

--- a/HelperOptionsBuilder.cs
+++ b/HelperOptionsBuilder.cs
@@ -147,6 +147,88 @@ namespace ScyllaDB.Alternator
             return this;
         }
 
+        public HelperOptionsBuilder WithMaxConnections(int maxConnections)
+        {
+            if (maxConnections <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxConnections));
+            }
+
+            this.options.MaxConnections = maxConnections;
+            return this;
+        }
+
+        public HelperOptionsBuilder WithMaxIdleHttpConnections(int maxIdleHttpConnections)
+        {
+            return this.WithMaxConnections(maxIdleHttpConnections);
+        }
+
+        public HelperOptionsBuilder WithMaxIdleHttpConnectionsPerHost(int maxIdleHttpConnectionsPerHost)
+        {
+            return this.WithMaxConnections(maxIdleHttpConnectionsPerHost);
+        }
+
+        public HelperOptionsBuilder WithConnectionMaxIdleTimeMs(long connectionMaxIdleTimeMs)
+        {
+            if (connectionMaxIdleTimeMs < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(connectionMaxIdleTimeMs));
+            }
+
+            this.options.ConnectionMaxIdleTimeMs = connectionMaxIdleTimeMs;
+            return this;
+        }
+
+        public HelperOptionsBuilder WithIdleHttpConnectionTimeoutMs(long idleHttpConnectionTimeoutMs)
+        {
+            return this.WithConnectionMaxIdleTimeMs(idleHttpConnectionTimeoutMs);
+        }
+
+        public HelperOptionsBuilder WithConnectionTimeToLiveMs(long connectionTimeToLiveMs)
+        {
+            if (connectionTimeToLiveMs < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(connectionTimeToLiveMs));
+            }
+
+            this.options.ConnectionTimeToLiveMs = connectionTimeToLiveMs;
+            return this;
+        }
+
+        public HelperOptionsBuilder WithConnectionAcquisitionTimeoutMs(long connectionAcquisitionTimeoutMs)
+        {
+            if (connectionAcquisitionTimeoutMs < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(connectionAcquisitionTimeoutMs));
+            }
+
+            this.options.ConnectionAcquisitionTimeoutMs = connectionAcquisitionTimeoutMs;
+            return this;
+        }
+
+        public HelperOptionsBuilder WithConnectionTimeoutMs(long connectionTimeoutMs)
+        {
+            if (connectionTimeoutMs < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(connectionTimeoutMs));
+            }
+
+            this.options.ConnectionTimeoutMs = connectionTimeoutMs;
+            this.options.HttpClientTimeoutMs = connectionTimeoutMs;
+            return this;
+        }
+
+        public HelperOptionsBuilder WithHttpClientTimeoutMs(long httpClientTimeoutMs)
+        {
+            if (httpClientTimeoutMs < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(httpClientTimeoutMs));
+            }
+
+            this.options.HttpClientTimeoutMs = httpClientTimeoutMs;
+            return this;
+        }
+
         public HelperOptionsBuilder WithTlsConfig(TlsConfig tlsConfig)
         {
             this.options.TlsConfig = tlsConfig ?? TlsConfig.TrustAll();

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
     .withConnectionTimeToLiveMs(60000)
     .withConnectionAcquisitionTimeoutMs(5000)
     .withConnectionTimeoutMs(3000)
+    .withHttpClientTimeoutMs(10000)
     .build();
 ```
 
@@ -185,7 +186,17 @@ AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
 | `connectionMaxIdleTimeMs` | 600000 | Maximum idle time for pooled connections. |
 | `connectionTimeToLiveMs` | 0 | Maximum lifetime for pooled connections; `0` means unlimited. |
 | `connectionAcquisitionTimeoutMs` | 10000 | Stored for Java API parity; .NET does not expose a separate per-pool acquisition timeout. |
-| `connectionTimeoutMs` | 15000 | Applied to `AmazonDynamoDBConfig.Timeout` and `SocketsHttpHandler.ConnectTimeout`. |
+| `connectionTimeoutMs` | 15000 | Applied to `SocketsHttpHandler.ConnectTimeout`. For compatibility, setting this also updates `httpClientTimeoutMs` unless that value is set later. |
+| `httpClientTimeoutMs` | 15000 | Applied to `AmazonDynamoDBConfig.Timeout`; use `0` to leave the AWS SDK timeout unchanged. |
+
+Additional HTTP transport aliases are available for callers using cross-SDK option names:
+
+| Alias | Effective C# setting | Notes |
+|---|---|---|
+| `maxIdleHttpConnections` | `maxConnections` | .NET exposes `SocketsHttpHandler.MaxConnectionsPerServer`, not a separate total idle-connection cap. |
+| `maxIdleHttpConnectionsPerHost` | `maxConnections` | Maps to the per-server connection limit. |
+| `idleHttpConnectionTimeoutMs` | `connectionMaxIdleTimeMs` | Maps to `SocketsHttpHandler.PooledConnectionIdleTimeout`. |
+| `httpClientTimeoutMs` | `AmazonDynamoDBConfig.Timeout` | Controls the whole request timeout independently from socket connect timeout. |
 
 ## TLS
 

--- a/UnitTests/ClientBuilderUnitTests.cs
+++ b/UnitTests/ClientBuilderUnitTests.cs
@@ -562,6 +562,51 @@ namespace ScyllaDB.Alternator
         }
 
         [Test]
+        public void AlternatorDynamoDBClientBuilderSupportsConnectionTuningAliasesTest()
+        {
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .endpointOverride("http://127.0.0.1:8080")
+                .withMaxIdleHttpConnections(61)
+                .withMaxIdleHttpConnectionsPerHost(62)
+                .withIdleHttpConnectionTimeoutMs(63000)
+                .withConnectionTimeoutMs(64000)
+                .withHttpClientTimeoutMs(65000)
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+
+            Assert.That(wrapper.Config.getMaxConnections(), Is.EqualTo(62));
+            Assert.That(wrapper.Config.getConnectionMaxIdleTimeMs(), Is.EqualTo(63000));
+            Assert.That(wrapper.Config.getConnectionTimeoutMs(), Is.EqualTo(64000));
+            Assert.That(wrapper.Config.getHttpClientTimeoutMs(), Is.EqualTo(65000));
+            Assert.That(wrapper.getClient().Config.Timeout, Is.EqualTo(TimeSpan.FromMilliseconds(65000)));
+            Assert.That(wrapper.getClient().Config.MaxConnectionsPerServer, Is.EqualTo(62));
+        }
+
+        [Test]
+        public void AlternatorDynamoDBClientBuilderPreservesSplitTimeoutsFromConfigTest()
+        {
+            var config = AlternatorConfig.builder()
+                .withSeedNode("http://127.0.0.1:8080")
+                .withConnectionTimeoutMs(71000)
+                .withHttpClientTimeoutMs(72000)
+                .build();
+
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .withAlternatorConfig(config)
+                .endpointOverride("http://127.0.0.1:8080")
+                .WithoutValidation()
+                .WithDeferredStart()
+                .buildWithAlternatorAPI();
+
+            var liveNodesConfig = GetAlternatorLiveNodesConfig(wrapper.getAlternatorLiveNodes());
+            Assert.That(wrapper.Config.getConnectionTimeoutMs(), Is.EqualTo(71000));
+            Assert.That(wrapper.Config.getHttpClientTimeoutMs(), Is.EqualTo(72000));
+            Assert.That(wrapper.getClient().Config.Timeout, Is.EqualTo(TimeSpan.FromMilliseconds(72000)));
+            Assert.That(liveNodesConfig.getHttpClientTimeoutMs(), Is.EqualTo(72000));
+        }
+
+        [Test]
         public void AlternatorDynamoDBClientBuilderSupportsCompressionAndHeaderOptimizationTest()
         {
             using var wrapper = AlternatorDynamoDBClient.builder()

--- a/UnitTests/ConfigValueObjectUnitTests.cs
+++ b/UnitTests/ConfigValueObjectUnitTests.cs
@@ -139,6 +139,33 @@ namespace ScyllaDB.Alternator
         }
 
         [Test]
+        public void AlternatorConfigBuilderSupportsConnectionTuningAliasesTest()
+        {
+            var config = AlternatorConfig.builder()
+                .withMaxIdleHttpConnections(51)
+                .withMaxIdleHttpConnectionsPerHost(52)
+                .withIdleHttpConnectionTimeoutMs(53000)
+                .withConnectionTimeoutMs(54000)
+                .build();
+
+            Assert.That(config.getMaxConnections(), Is.EqualTo(52));
+            Assert.That(config.getConnectionMaxIdleTimeMs(), Is.EqualTo(53000));
+            Assert.That(config.getConnectionTimeoutMs(), Is.EqualTo(54000));
+            Assert.That(config.getHttpClientTimeoutMs(), Is.EqualTo(54000));
+
+            var splitTimeouts = AlternatorConfig.Builder()
+                .WithConnectionTimeoutMs(11000)
+                .WithHttpClientTimeoutMs(12000)
+                .Build();
+            Assert.That(splitTimeouts.ConnectionTimeoutMs, Is.EqualTo(11000));
+            Assert.That(splitTimeouts.HttpClientTimeoutMs, Is.EqualTo(12000));
+
+            Assert.Throws<ArgumentException>(() => AlternatorConfig.builder()
+                .withHttpClientTimeoutMs(-1)
+                .build());
+        }
+
+        [Test]
         public void AlternatorConfigBuilderComputesOptimizedHeadersFromEffectiveConfigTest()
         {
             var minimal = AlternatorConfig.builder()

--- a/UnitTests/HelperOptionsBuilderUnitTests.cs
+++ b/UnitTests/HelperOptionsBuilderUnitTests.cs
@@ -125,5 +125,35 @@ namespace ScyllaDB.Alternator
             Assert.That(wrapper.Config.ResponseCompressionAlgorithms, Is.EqualTo(new[] { ResponseCompressionAlgorithm.Gzip }));
             Assert.That(disabledWrapper.Config.ResponseCompressionAlgorithms, Is.Empty);
         }
+
+        [Test]
+        [Category("Unit")]
+        public void HelperOptionsBuilderSupportsConnectionTuningAliasesTest()
+        {
+            var options = HelperOptionsBuilder.Create()
+                .WithInitialNodeUri(new Uri("http://127.0.0.1:8080"))
+                .WithMaxIdleHttpConnections(71)
+                .WithMaxIdleHttpConnectionsPerHost(72)
+                .WithIdleHttpConnectionTimeoutMs(73000)
+                .WithConnectionTimeToLiveMs(74000)
+                .WithConnectionAcquisitionTimeoutMs(75000)
+                .WithConnectionTimeoutMs(76000)
+                .WithHttpClientTimeoutMs(77000)
+                .WithoutValidation()
+                .WithDeferredStart()
+                .Build();
+
+            using var wrapper = AlternatorDynamoDBClient.builder()
+                .WithOptions(options)
+                .buildWithAlternatorAPI();
+
+            Assert.That(wrapper.Config.MaxConnections, Is.EqualTo(72));
+            Assert.That(wrapper.Config.ConnectionMaxIdleTimeMs, Is.EqualTo(73000));
+            Assert.That(wrapper.Config.ConnectionTimeToLiveMs, Is.EqualTo(74000));
+            Assert.That(wrapper.Config.ConnectionAcquisitionTimeoutMs, Is.EqualTo(75000));
+            Assert.That(wrapper.Config.ConnectionTimeoutMs, Is.EqualTo(76000));
+            Assert.That(wrapper.Config.HttpClientTimeoutMs, Is.EqualTo(77000));
+            Assert.That(wrapper.getClient().Config.Timeout, Is.EqualTo(TimeSpan.FromMilliseconds(77000)));
+        }
     }
 }

--- a/UnitTests/RequestPipelineUnitTests.cs
+++ b/UnitTests/RequestPipelineUnitTests.cs
@@ -139,6 +139,25 @@ namespace ScyllaDB.Alternator
         }
 
         [Test]
+        public void AlternatorHttpClientFactoryAppliesConnectionTuningToSocketsHandlerTest()
+        {
+            var config = AlternatorConfig.builder()
+                .withMaxIdleHttpConnectionsPerHost(82)
+                .withIdleHttpConnectionTimeoutMs(83000)
+                .withConnectionTimeToLiveMs(84000)
+                .withConnectionTimeoutMs(85000)
+                .withHttpClientTimeoutMs(86000)
+                .build();
+
+            using var handler = CreateAlternatorSocketsHttpHandler(config, _ => { });
+
+            Assert.That(handler.MaxConnectionsPerServer, Is.EqualTo(82));
+            Assert.That(handler.PooledConnectionIdleTimeout, Is.EqualTo(TimeSpan.FromMilliseconds(83000)));
+            Assert.That(handler.PooledConnectionLifetime, Is.EqualTo(TimeSpan.FromMilliseconds(84000)));
+            Assert.That(handler.ConnectTimeout, Is.EqualTo(TimeSpan.FromMilliseconds(85000)));
+        }
+
+        [Test]
         public void AlternatorHttpClientFactoryRejectsSystemTrustedCertificateWithHostnameMismatchTest()
         {
             using var certificate = LoadSystemTrustedCertificate();


### PR DESCRIPTION
## Summary
- add HTTP transport alias methods for idle pool size, per-host idle pool size, idle timeout, and whole request timeout
- keep existing connection tuning methods working while separating socket connect timeout from AWS SDK request timeout
- document the .NET mapping and cover config, helper, client builder, and socket handler behavior in tests

## Tests
- dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj --no-restore
- dotnet build ScyllaDB.Alternator.sln --no-restore