### PR TITLE
Prefer active nodes for affinity routing

### DIFF
--- a/AlternatorLiveNodes.cs
+++ b/AlternatorLiveNodes.cs
@@ -259,6 +259,16 @@ namespace ScyllaDB.Alternator
             }
         }
 
+        public IReadOnlyList<Uri> GetActiveNodes()
+        {
+            return this.GetActiveNodesInternal().ToList().AsReadOnly();
+        }
+
+        public IReadOnlyList<Uri> GetQuarantinedNodes()
+        {
+            return this.GetQuarantinedNodesInternal().ToList().AsReadOnly();
+        }
+
         public Uri NextAsUri(string? path, string? query)
         {
             Uri uri = this.NextAsUri();
@@ -409,6 +419,16 @@ namespace ScyllaDB.Alternator
         {
             return this.GetLiveNodes();
         }
+
+        public IReadOnlyList<Uri> getActiveNodes()
+        {
+            return this.GetActiveNodes();
+        }
+
+        public IReadOnlyList<Uri> getQuarantinedNodes()
+        {
+            return this.GetQuarantinedNodes();
+        }
 #pragma warning restore SA1300, IDE1006
 
         internal Uri GetNodeForHash(long hash)
@@ -455,10 +475,30 @@ namespace ScyllaDB.Alternator
             }
         }
 
+        protected internal virtual IReadOnlyList<Uri> GetActiveNodesInternal()
+        {
+            return this.GetLiveNodesInternal();
+        }
+
+        protected internal virtual IReadOnlyList<Uri> GetQuarantinedNodesInternal()
+        {
+            return Array.Empty<Uri>();
+        }
+
 #pragma warning disable SA1300, IDE1006
         protected internal virtual IReadOnlyList<Uri> getLiveNodesInternal()
         {
             return this.GetLiveNodesInternal();
+        }
+
+        protected internal virtual IReadOnlyList<Uri> getActiveNodesInternal()
+        {
+            return this.GetActiveNodesInternal();
+        }
+
+        protected internal virtual IReadOnlyList<Uri> getQuarantinedNodesInternal()
+        {
+            return this.GetQuarantinedNodesInternal();
         }
 #pragma warning restore SA1300, IDE1006
 

--- a/IntegrationTests/IntegrationTests.cs
+++ b/IntegrationTests/IntegrationTests.cs
@@ -101,6 +101,8 @@ namespace ScyllaDB.Alternator
                 .BuildWithAlternatorAPI();
 
             await WaitUntilAsync(() => wrapper.getLiveNodes().Count > 0);
+            var liveNodesManager = wrapper.getAlternatorLiveNodes();
+            liveNodesManager.shutdownAndWait();
             var liveNodes = wrapper.getLiveNodes();
             var next = wrapper.nextAsURI();
             var config = wrapper.GetAlternatorConfig();
@@ -108,7 +110,7 @@ namespace ScyllaDB.Alternator
             Assert.That(wrapper.getClient(), Is.InstanceOf<AmazonDynamoDBClient>());
             Assert.That(config, Is.Not.Null);
             Assert.That(config!.SeedHosts, Is.Not.Empty);
-            Assert.That(wrapper.getAlternatorLiveNodes().getLiveNodes(), Is.EqualTo(liveNodes));
+            Assert.That(liveNodesManager.getLiveNodes(), Is.EqualTo(liveNodes));
             Assert.That(liveNodes, Does.Contain(next));
         }
 

--- a/KeyRouting/LazyQueryPlan.cs
+++ b/KeyRouting/LazyQueryPlan.cs
@@ -12,6 +12,7 @@ namespace ScyllaDB.Alternator.KeyRouting
         private readonly List<Uri>? preferredNodes;
         private readonly HashSet<Uri> usedNodes = new HashSet<Uri>();
         private List<Uri>? remaining;
+        private List<Uri>? fallbackRemaining;
         private bool initialized;
         private Uri? nextNode;
 
@@ -65,7 +66,7 @@ namespace ScyllaDB.Alternator.KeyRouting
                 if (this.random != null || this.preferredNodes != null || this.fixedNodes != null)
                 {
                     this.EnsureInitialized();
-                    return this.remaining!.Count != 0;
+                    return this.HasRemainingInitializedNodes();
                 }
 
                 return this.ComputeNextNonSeeded() != null;
@@ -74,7 +75,7 @@ namespace ScyllaDB.Alternator.KeyRouting
 
         public static List<Uri> SortedAffinityNodes(AlternatorLiveNodes liveNodes)
         {
-            var nodes = GetLiveNodes(liveNodes);
+            var nodes = GetPrimaryNodes(liveNodes);
             SortAffinityNodes(nodes);
             return nodes;
         }
@@ -109,7 +110,15 @@ namespace ScyllaDB.Alternator.KeyRouting
                 this.EnsureInitialized();
                 if (this.remaining!.Count == 0)
                 {
-                    throw new InvalidOperationException("No more nodes available in query plan");
+                    if (this.fallbackRemaining?.Count > 0)
+                    {
+                        this.remaining = this.fallbackRemaining;
+                        this.fallbackRemaining = null;
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException("No more nodes available in query plan");
+                    }
                 }
 
                 var index = this.random.Intn(this.remaining.Count);
@@ -125,7 +134,15 @@ namespace ScyllaDB.Alternator.KeyRouting
                 this.EnsureInitialized();
                 if (this.remaining!.Count == 0)
                 {
-                    throw new InvalidOperationException("No more nodes available in query plan");
+                    if (this.fallbackRemaining?.Count > 0)
+                    {
+                        this.remaining = this.fallbackRemaining;
+                        this.fallbackRemaining = null;
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException("No more nodes available in query plan");
+                    }
                 }
 
                 var node = this.remaining[0];
@@ -174,14 +191,29 @@ namespace ScyllaDB.Alternator.KeyRouting
         }
 #pragma warning restore SA1300, IDE1006
 
-        private static List<Uri> GetLiveNodes(AlternatorLiveNodes liveNodes)
+        private static List<Uri> GetPrimaryNodes(AlternatorLiveNodes liveNodes)
         {
             if (liveNodes == null)
             {
                 throw new ArgumentException("liveNodes cannot be null", nameof(liveNodes));
             }
 
-            return liveNodes.GetLiveNodesInternal().ToList();
+            var activeNodes = liveNodes.GetActiveNodesInternal().ToList();
+            return activeNodes.Count != 0
+                ? activeNodes
+                : liveNodes.GetQuarantinedNodesInternal().ToList();
+        }
+
+        private static List<Uri> GetFallbackNodes(AlternatorLiveNodes liveNodes)
+        {
+            if (liveNodes == null)
+            {
+                throw new ArgumentException("liveNodes cannot be null", nameof(liveNodes));
+            }
+
+            return liveNodes.GetActiveNodesInternal().Count != 0
+                ? liveNodes.GetQuarantinedNodesInternal().ToList()
+                : new List<Uri>();
         }
 
         private static void SortAffinityNodes(List<Uri> nodes)
@@ -226,14 +258,23 @@ namespace ScyllaDB.Alternator.KeyRouting
             }
             else
             {
-                this.remaining = SortedAffinityNodes(this.liveNodes!);
+                this.remaining = GetPrimaryNodes(this.liveNodes!);
+                this.fallbackRemaining = GetFallbackNodes(this.liveNodes!);
+                SortAffinityNodes(this.remaining);
+                SortAffinityNodes(this.fallbackRemaining);
                 if (this.preferredNodes != null)
                 {
                     this.remaining = OrderPreferredNodesFirst(this.remaining, this.preferredNodes);
+                    this.fallbackRemaining = OrderPreferredNodesFirst(this.fallbackRemaining, this.preferredNodes);
                 }
             }
 
             this.initialized = true;
+        }
+
+        private bool HasRemainingInitializedNodes()
+        {
+            return this.remaining!.Count != 0 || this.fallbackRemaining?.Count > 0;
         }
 
         private Uri? ComputeNextNonSeeded()
@@ -255,9 +296,16 @@ namespace ScyllaDB.Alternator.KeyRouting
                 return this.nextNode;
             }
 
-            var availableNodes = this.liveNodes.GetLiveNodesInternal()
+            var availableNodes = this.liveNodes.GetActiveNodesInternal()
                 .Where(node => !this.usedNodes.Contains(node))
                 .ToList();
+            if (availableNodes.Count == 0)
+            {
+                availableNodes = this.liveNodes.GetQuarantinedNodesInternal()
+                    .Where(node => !this.usedNodes.Contains(node))
+                    .ToList();
+            }
+
             if (availableNodes.Count == 0)
             {
                 return null;

--- a/UnitTests/KeyRoutingUnitTests.cs
+++ b/UnitTests/KeyRoutingUnitTests.cs
@@ -695,6 +695,64 @@ namespace ScyllaDB.Alternator
                 Is.EqualTo(LazyQueryPlan.preferredNodeForHash(sortedLiveNodes, 42L)));
         }
 
+        [Test]
+        public void LazyQueryPlanUsesActiveNodesBeforeQuarantinedFallbackTest()
+        {
+            var activeNodes = Uris("node4", "node2");
+            var quarantinedNodes = Uris("node3", "node1");
+            var liveNodes = new HealthSplitLiveNodes(activeNodes, quarantinedNodes);
+            var plan = new LazyQueryPlan(liveNodes, 42L);
+
+            var activePlanNodes = DrainQueryPlanUris(plan, activeNodes.Count);
+            var fallbackPlanNodes = DrainQueryPlanUris(plan, quarantinedNodes.Count);
+            var preferredNode = LazyQueryPlan.preferredNodeForHash(liveNodes, 42L);
+
+            Assert.That(liveNodes.getActiveNodes(), Is.EqualTo(activeNodes));
+            Assert.That(liveNodes.getQuarantinedNodes(), Is.EqualTo(quarantinedNodes));
+            Assert.That(LazyQueryPlan.sortedAffinityNodes(liveNodes), Is.EqualTo(SortUris(activeNodes)));
+            Assert.That(activeNodes, Does.Contain(preferredNode));
+            Assert.That(activePlanNodes, Is.EquivalentTo(activeNodes));
+            Assert.That(fallbackPlanNodes, Is.EquivalentTo(quarantinedNodes));
+            Assert.That(plan.hasNext(), Is.False);
+        }
+
+        [Test]
+        public void LazyQueryPlanUsesQuarantinedNodesWhenNoActiveNodesTest()
+        {
+            var quarantinedNodes = Uris("node3", "node1", "node2");
+            var liveNodes = new HealthSplitLiveNodes(Array.Empty<Uri>(), quarantinedNodes);
+            var plan = new LazyQueryPlan(liveNodes, 42L);
+
+            var planNodes = DrainQueryPlanUris(plan, quarantinedNodes.Count);
+
+            Assert.That(LazyQueryPlan.sortedAffinityNodes(liveNodes), Is.EqualTo(SortUris(quarantinedNodes)));
+            Assert.That(planNodes, Is.EquivalentTo(quarantinedNodes));
+            Assert.That(plan.hasNext(), Is.False);
+        }
+
+        [Test]
+        public void AffinityBatchWriteVotingUsesActiveNodesBeforeQuarantinedFallbackTest()
+        {
+            var activeNodes = Uris("node2");
+            var quarantinedNodes = Uris("node1", "node3");
+            var liveNodes = new HealthSplitLiveNodes(activeNodes, quarantinedNodes);
+            var affinity = BatchWriteAffinityConfig(PkInfo("orders", "id"));
+            var interceptor = new AffinityQueryPlanInterceptor(affinity, liveNodes);
+            var request = BatchWrite(
+                Table(
+                    "orders",
+                    Put(ItemWithId("order-1", "payload-a")),
+                    Delete(KeyWithId("order-2")),
+                    Put(ItemWithId("order-3", "payload-b"))));
+
+            var queryPlan = InvokeTryCreateBatchWriteAffinityQueryPlan(interceptor, request);
+            Assert.That(queryPlan, Is.Not.Null);
+            var planNodes = DrainQueryPlanUris(queryPlan!, activeNodes.Count + quarantinedNodes.Count);
+
+            Assert.That(planNodes.Take(activeNodes.Count), Is.EqualTo(activeNodes));
+            Assert.That(planNodes.Skip(activeNodes.Count), Is.EquivalentTo(quarantinedNodes));
+        }
+
         private static Helper CreateHelperForNodes(params string[] hosts)
         {
             var config = AlternatorConfig.builder()
@@ -791,7 +849,7 @@ namespace ScyllaDB.Alternator
         }
 
         private static object? InvokeTryCreateBatchWriteAffinityQueryPlan(
-            QueryPlanPipelineHandler handler,
+            AffinityQueryPlanInterceptor handler,
             BatchWriteItemRequest request)
         {
             var method = typeof(AffinityQueryPlanInterceptor).GetMethod(
@@ -802,6 +860,18 @@ namespace ScyllaDB.Alternator
                 null);
             Assert.That(method, Is.Not.Null);
             return method!.Invoke(handler, new object[] { request });
+        }
+
+        private static List<Uri> Uris(params string[] hosts)
+        {
+            return hosts.Select(host => new Uri($"http://{host}.example.com:8043")).ToList();
+        }
+
+        private static List<Uri> SortUris(IEnumerable<Uri> uris)
+        {
+            var sorted = uris.ToList();
+            sorted.Sort((left, right) => string.Compare(left.ToString(), right.ToString(), StringComparison.Ordinal));
+            return sorted;
         }
 
         private static Uri NodeForPartitionKeyValue(Helper helper, AttributeValue value)
@@ -974,6 +1044,40 @@ namespace ScyllaDB.Alternator
             {
                 cancellation.Token.ThrowIfCancellationRequested();
                 await Task.Delay(20, cancellation.Token);
+            }
+        }
+
+        private sealed class HealthSplitLiveNodes : AlternatorLiveNodes
+        {
+            private readonly IReadOnlyList<Uri> activeNodes;
+            private readonly IReadOnlyList<Uri> quarantinedNodes;
+
+            internal HealthSplitLiveNodes(IEnumerable<Uri> activeNodes, IEnumerable<Uri> quarantinedNodes)
+                : base(BuildSeedNodes(activeNodes, quarantinedNodes), "http", 8043, string.Empty, string.Empty)
+            {
+                this.activeNodes = activeNodes.ToList().AsReadOnly();
+                this.quarantinedNodes = quarantinedNodes.ToList().AsReadOnly();
+            }
+
+            protected override IReadOnlyList<Uri> GetActiveNodesInternal()
+            {
+                return this.activeNodes;
+            }
+
+            protected override IReadOnlyList<Uri> GetQuarantinedNodesInternal()
+            {
+                return this.quarantinedNodes;
+            }
+
+            private static List<Uri> BuildSeedNodes(IEnumerable<Uri> activeNodes, IEnumerable<Uri> quarantinedNodes)
+            {
+                var seedNodes = activeNodes.Concat(quarantinedNodes).ToList();
+                if (seedNodes.Count == 0)
+                {
+                    seedNodes.Add(new Uri("http://seed.example.com:8043"));
+                }
+
+                return seedNodes;
             }
         }
     }


### PR DESCRIPTION
## Summary
- expose active and quarantined node views from the live-node manager
- make affinity query plans consume active nodes before quarantined fallback nodes
- cover seeded plans, all-fallback behavior, and BatchWrite voting with unit tests

## Tests
- dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj --no-restore
- dotnet build ScyllaDB.Alternator.sln --no-restore