### PR TITLE
Revert User-Agent composition change

### DIFF
--- a/AlternatorUserAgent.cs
+++ b/AlternatorUserAgent.cs
@@ -97,26 +97,13 @@ namespace ScyllaDB.Alternator
 
         private static string? Transform(string? current, Func<string, string?>? transformer, bool appendDefaultToken)
         {
-            var userAgent = appendDefaultToken ? AppendDefaultToken(current) : current;
+            var userAgent = appendDefaultToken ? UserAgentToken : current;
             if (transformer != null)
             {
                 userAgent = transformer(userAgent ?? string.Empty);
             }
 
             return string.IsNullOrWhiteSpace(userAgent) ? null : userAgent.Trim();
-        }
-
-        private static string AppendDefaultToken(string? current)
-        {
-            if (string.IsNullOrWhiteSpace(current))
-            {
-                return UserAgentToken;
-            }
-
-            var trimmed = current.Trim();
-            return trimmed.Contains(UserAgentToken, StringComparison.Ordinal)
-                ? trimmed
-                : trimmed + " " + UserAgentToken;
         }
 
         private static string ResolveVersion()

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
 
 ## User-Agent
 
-By default, the client preserves the AWS SDK user-agent and appends a ScyllaDB Alternator token. The builder can replace, transform, append to, or remove the final user-agent.
+By default, the client appends a ScyllaDB Alternator token to the AWS SDK user-agent. The builder can replace, transform, or remove the final user-agent.
 
 ```csharp
 AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
@@ -363,8 +363,6 @@ AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
     .withUserAgent(userAgent => userAgent + " my-app/1.0")
     .build();
 ```
-
-Use `withUserAgent("custom/1.0")` to replace the final value. Use `withUserAgent(userAgent => ...)` to transform the current composed value. Use `withoutUserAgent()` to remove it; header optimization then no longer requires the `User-Agent` header.
 
 ```csharp
 AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()

--- a/UnitTests/RequestPipelineUnitTests.cs
+++ b/UnitTests/RequestPipelineUnitTests.cs
@@ -369,7 +369,7 @@ namespace ScyllaDB.Alternator
         }
 
         [Test]
-        public void AlternatorUserAgentApplyToRequestAppendsTokenToAwsSdkUserAgentHeaderTest()
+        public void AlternatorUserAgentApplyToRequestReplacesAwsSdkUserAgentHeaderTest()
         {
             var token = GetAlternatorUserAgentToken();
             var applyTo = GetAlternatorUserAgentApplyTo();
@@ -381,7 +381,8 @@ namespace ScyllaDB.Alternator
 
             applyTo(request, headers);
 
-            Assert.That(headers["User-Agent"], Is.EqualTo("aws-sdk-dotnet/4.x " + token));
+            Assert.That(headers["User-Agent"], Is.EqualTo(token));
+            Assert.That(headers["User-Agent"], Does.Not.Contain("aws-sdk-dotnet"));
         }
 
         [Test]
@@ -404,15 +405,7 @@ namespace ScyllaDB.Alternator
                 ["User-Agent"] = "aws-sdk-dotnet/4.x",
             };
             applyTo(transformRequest, transformHeaders, userAgent => "prefix " + userAgent + " suffix", true);
-            Assert.That(transformHeaders["User-Agent"], Is.EqualTo("prefix aws-sdk-dotnet/4.x " + token + " suffix"));
-
-            var appendRequest = new PutItemRequest();
-            var appendHeaders = new Dictionary<string, string>
-            {
-                ["User-Agent"] = "aws-sdk-dotnet/4.x",
-            };
-            applyTo(appendRequest, appendHeaders, userAgent => userAgent + " my-app/1.0", true);
-            Assert.That(appendHeaders["User-Agent"], Is.EqualTo("aws-sdk-dotnet/4.x " + token + " my-app/1.0"));
+            Assert.That(transformHeaders["User-Agent"], Is.EqualTo("prefix " + token + " suffix"));
 
             var removeRequest = new PutItemRequest();
             var removeHeaders = new Dictionary<string, string>


### PR DESCRIPTION
## Summary
- revert PR #59
- restore the prior User-Agent behavior and tests

## Tests
- dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj --no-restore
- dotnet build ScyllaDB.Alternator.sln --no-restore