### PR TITLE
Implement node health handling

### DIFF
--- a/AlternatorConfig.cs
+++ b/AlternatorConfig.cs
@@ -18,10 +18,10 @@ namespace ScyllaDB.Alternator
         public const long DefaultConnectionAcquisitionTimeoutMs = 10000;
         public const long DefaultConnectionTimeoutMs = 15000;
         public const long DefaultHttpClientTimeoutMs = DefaultConnectionTimeoutMs;
-        public const int DefaultConsecutiveServerErrorThreshold = 3;
-        public const int DefaultQuarantineSuccessThreshold = 3;
+        public const int DefaultConsecutiveServerErrorThreshold = 10;
+        public const int DefaultQuarantineSuccessThreshold = 10;
         public const long DefaultDownNodeProbePeriodMs = 30000;
-        public const int DefaultQuarantineTrafficInterval = 10;
+        public const int DefaultQuarantinedNodeSamplingInterval = 10;
         public const long DefaultServerRequestTimeoutThresholdMs = 9000;
         public const int RecommendedPartitionKeyDiscoveryMaxRetries = 3;
         public const long RecommendedPartitionKeyDiscoveryInitialDelayMs = 100;
@@ -41,7 +41,7 @@ namespace ScyllaDB.Alternator
         public const int DEFAULT_CONSECUTIVE_SERVER_ERROR_THRESHOLD = DefaultConsecutiveServerErrorThreshold;
         public const int DEFAULT_QUARANTINE_SUCCESS_THRESHOLD = DefaultQuarantineSuccessThreshold;
         public const long DEFAULT_DOWN_NODE_PROBE_PERIOD_MS = DefaultDownNodeProbePeriodMs;
-        public const int DEFAULT_QUARANTINE_TRAFFIC_INTERVAL = DefaultQuarantineTrafficInterval;
+        public const int DEFAULT_QUARANTINED_NODE_SAMPLING_INTERVAL = DefaultQuarantinedNodeSamplingInterval;
         public const long DEFAULT_SERVER_REQUEST_TIMEOUT_THRESHOLD_MS = DefaultServerRequestTimeoutThresholdMs;
         public const int RECOMMENDED_PARTITION_KEY_DISCOVERY_MAX_RETRIES = RecommendedPartitionKeyDiscoveryMaxRetries;
         public const long RECOMMENDED_PARTITION_KEY_DISCOVERY_INITIAL_DELAY_MS = RecommendedPartitionKeyDiscoveryInitialDelayMs;

--- a/AlternatorConfig.cs
+++ b/AlternatorConfig.cs
@@ -18,6 +18,11 @@ namespace ScyllaDB.Alternator
         public const long DefaultConnectionAcquisitionTimeoutMs = 10000;
         public const long DefaultConnectionTimeoutMs = 15000;
         public const long DefaultHttpClientTimeoutMs = DefaultConnectionTimeoutMs;
+        public const int DefaultConsecutiveServerErrorThreshold = 3;
+        public const int DefaultQuarantineSuccessThreshold = 3;
+        public const long DefaultDownNodeProbePeriodMs = 30000;
+        public const int DefaultQuarantineTrafficInterval = 10;
+        public const long DefaultServerRequestTimeoutThresholdMs = 9000;
         public const int RecommendedPartitionKeyDiscoveryMaxRetries = 3;
         public const long RecommendedPartitionKeyDiscoveryInitialDelayMs = 100;
         public const long RecommendedPartitionKeyDiscoveryMaxDelayMs = 2000;
@@ -33,6 +38,11 @@ namespace ScyllaDB.Alternator
         public const long DEFAULT_CONNECTION_ACQUISITION_TIMEOUT_MS = DefaultConnectionAcquisitionTimeoutMs;
         public const long DEFAULT_CONNECTION_TIMEOUT_MS = DefaultConnectionTimeoutMs;
         public const long DEFAULT_HTTP_CLIENT_TIMEOUT_MS = DefaultHttpClientTimeoutMs;
+        public const int DEFAULT_CONSECUTIVE_SERVER_ERROR_THRESHOLD = DefaultConsecutiveServerErrorThreshold;
+        public const int DEFAULT_QUARANTINE_SUCCESS_THRESHOLD = DefaultQuarantineSuccessThreshold;
+        public const long DEFAULT_DOWN_NODE_PROBE_PERIOD_MS = DefaultDownNodeProbePeriodMs;
+        public const int DEFAULT_QUARANTINE_TRAFFIC_INTERVAL = DefaultQuarantineTrafficInterval;
+        public const long DEFAULT_SERVER_REQUEST_TIMEOUT_THRESHOLD_MS = DefaultServerRequestTimeoutThresholdMs;
         public const int RECOMMENDED_PARTITION_KEY_DISCOVERY_MAX_RETRIES = RecommendedPartitionKeyDiscoveryMaxRetries;
         public const long RECOMMENDED_PARTITION_KEY_DISCOVERY_INITIAL_DELAY_MS = RecommendedPartitionKeyDiscoveryInitialDelayMs;
         public const long RECOMMENDED_PARTITION_KEY_DISCOVERY_MAX_DELAY_MS = RecommendedPartitionKeyDiscoveryMaxDelayMs;
@@ -102,7 +112,8 @@ namespace ScyllaDB.Alternator
             long connectionAcquisitionTimeoutMs,
             long connectionTimeoutMs,
             long httpClientTimeoutMs,
-            TlsConfig tlsConfig)
+            TlsConfig tlsConfig,
+            NodeHealthStoreConfig nodeHealth)
         {
             this.SeedHosts = seedHosts.AsReadOnly();
             this.Scheme = scheme;
@@ -127,6 +138,7 @@ namespace ScyllaDB.Alternator
             this.ConnectionTimeoutMs = connectionTimeoutMs;
             this.HttpClientTimeoutMs = httpClientTimeoutMs;
             this.TlsConfig = tlsConfig;
+            this.NodeHealth = NodeHealthStoreConfig.Normalize(nodeHealth);
             this.HeadersWhitelist = this.CreateHeadersWhitelist(headersWhitelist, customOptimizeHeaders);
         }
 
@@ -171,6 +183,8 @@ namespace ScyllaDB.Alternator
         public long HttpClientTimeoutMs { get; }
 
         public TlsConfig TlsConfig { get; }
+
+        public NodeHealthStoreConfig NodeHealth { get; }
 
         public IReadOnlySet<string> RequiredHeaders => this.GetRequiredHeaders();
 
@@ -315,6 +329,11 @@ namespace ScyllaDB.Alternator
         public long getHttpClientTimeoutMs()
         {
             return this.HttpClientTimeoutMs;
+        }
+
+        public NodeHealthStoreConfig getNodeHealth()
+        {
+            return this.NodeHealth;
         }
 
         public IReadOnlySet<string> getRequiredHeaders()

--- a/AlternatorConfigBuilder.cs
+++ b/AlternatorConfigBuilder.cs
@@ -37,6 +37,7 @@ namespace ScyllaDB.Alternator
         private long connectionTimeoutMs = AlternatorConfig.DefaultConnectionTimeoutMs;
         private long httpClientTimeoutMs = AlternatorConfig.DefaultHttpClientTimeoutMs;
         private TlsConfig? tlsConfig;
+        private NodeHealthStoreConfig nodeHealth = new NodeHealthStoreConfig();
 
         public AlternatorConfigBuilder WithSeedNode(Uri? seedUri)
         {
@@ -270,6 +271,12 @@ namespace ScyllaDB.Alternator
             return this;
         }
 
+        public AlternatorConfigBuilder WithNodeHealth(NodeHealthStoreConfig? config)
+        {
+            this.nodeHealth = NodeHealthStoreConfig.Normalize(config);
+            return this;
+        }
+
 #pragma warning disable SA1300, IDE1006
         public AlternatorConfigBuilder withSeedNode(Uri? seedUri)
         {
@@ -446,6 +453,11 @@ namespace ScyllaDB.Alternator
             return this.WithHttpClientTimeoutMs(httpClientTimeoutMs);
         }
 
+        public AlternatorConfigBuilder withNodeHealth(NodeHealthStoreConfig? config)
+        {
+            return this.WithNodeHealth(config);
+        }
+
         public AlternatorConfig build()
         {
             return this.Build();
@@ -512,7 +524,8 @@ namespace ScyllaDB.Alternator
                 this.connectionAcquisitionTimeoutMs,
                 this.connectionTimeoutMs,
                 this.httpClientTimeoutMs,
-                effectiveTlsConfig);
+                effectiveTlsConfig,
+                this.nodeHealth);
         }
 
         private TlsConfig CreateEffectiveTlsConfig()

--- a/AlternatorDynamoDBClientBuilder.cs
+++ b/AlternatorDynamoDBClientBuilder.cs
@@ -429,6 +429,13 @@ namespace ScyllaDB.Alternator
             return this;
         }
 
+        public AlternatorDynamoDBClientBuilder WithNodeHealth(NodeHealthStoreConfig? config)
+        {
+            this.optionsBuilder.WithNodeHealth(config);
+            this.configBuilder.WithNodeHealth(config);
+            return this;
+        }
+
         public AlternatorDynamoDBClientBuilder WithDisableCertificateChecks()
         {
             this.disableCertificateChecks = true;
@@ -795,6 +802,11 @@ namespace ScyllaDB.Alternator
             return this.WithHttpClientTimeoutMs(httpClientTimeoutMs);
         }
 
+        public AlternatorDynamoDBClientBuilder withNodeHealth(NodeHealthStoreConfig? config)
+        {
+            return this.WithNodeHealth(config);
+        }
+
         public AlternatorDynamoDBClientBuilder withDisableCertificateChecks()
         {
             return this.WithDisableCertificateChecks();
@@ -928,7 +940,8 @@ namespace ScyllaDB.Alternator
                 .WithConnectionTimeToLiveMs(config.ConnectionTimeToLiveMs)
                 .WithConnectionAcquisitionTimeoutMs(config.ConnectionAcquisitionTimeoutMs)
                 .WithConnectionTimeoutMs(config.ConnectionTimeoutMs)
-                .WithHttpClientTimeoutMs(config.HttpClientTimeoutMs);
+                .WithHttpClientTimeoutMs(config.HttpClientTimeoutMs)
+                .WithNodeHealth(config.NodeHealth);
 
             config.CopyHeaderOptimizationTo(builder);
             return builder.Build();
@@ -991,6 +1004,7 @@ namespace ScyllaDB.Alternator
             dynamoDbConfig.MaxConnectionsPerServer = alternatorConfig.MaxConnections;
             dynamoDbConfig.HttpClientFactory ??= new AlternatorHttpClientFactory(
                 alternatorConfig,
+                endpointProvider.GetAlternatorLiveNodes(),
                 this.configureHttpClientHandler,
                 this.configureSocketsHttpHandler);
             this.configureAws?.Invoke(dynamoDbConfig);
@@ -1143,7 +1157,8 @@ namespace ScyllaDB.Alternator
                 .WithConnectionTimeToLiveMs(config.ConnectionTimeToLiveMs)
                 .WithConnectionAcquisitionTimeoutMs(config.ConnectionAcquisitionTimeoutMs)
                 .WithConnectionTimeoutMs(config.ConnectionTimeoutMs)
-                .WithHttpClientTimeoutMs(config.HttpClientTimeoutMs);
+                .WithHttpClientTimeoutMs(config.HttpClientTimeoutMs)
+                .WithNodeHealth(config.NodeHealth);
             config.CopyHeaderOptimizationTo(this.configBuilder);
         }
 

--- a/AlternatorHttpClientFactory.cs
+++ b/AlternatorHttpClientFactory.cs
@@ -13,15 +13,18 @@ namespace ScyllaDB.Alternator
     internal sealed class AlternatorHttpClientFactory : HttpClientFactory
     {
         private readonly AlternatorConfig config;
+        private readonly AlternatorLiveNodes? liveNodes;
         private readonly Action<HttpClientHandler>? configureHttpClientHandler;
         private readonly Action<SocketsHttpHandler>? configureSocketsHttpHandler;
 
         internal AlternatorHttpClientFactory(
             AlternatorConfig config,
+            AlternatorLiveNodes? liveNodes = null,
             Action<HttpClientHandler>? configureHttpClientHandler = null,
             Action<SocketsHttpHandler>? configureSocketsHttpHandler = null)
         {
             this.config = config;
+            this.liveNodes = liveNodes;
             this.configureHttpClientHandler = configureHttpClientHandler;
             this.configureSocketsHttpHandler = configureSocketsHttpHandler;
         }
@@ -32,6 +35,11 @@ namespace ScyllaDB.Alternator
                 this.config,
                 this.configureHttpClientHandler,
                 this.configureSocketsHttpHandler);
+            if (this.liveNodes != null)
+            {
+                handler = new NodeHealthReportingHttpMessageHandler(handler, this.liveNodes, this.config.NodeHealth);
+            }
+
             if (this.config.OptimizeHeaders)
             {
                 handler = new HeadersFilteringHttpMessageHandler(handler, this.config.HeadersWhitelist);

--- a/AlternatorLiveNodes.cs
+++ b/AlternatorLiveNodes.cs
@@ -939,7 +939,7 @@ namespace ScyllaDB.Alternator
             if (!activeNodesEmpty)
             {
                 var trafficSequence = Interlocked.Increment(ref this.nextQuarantineTrafficSequence);
-                if (Mod(trafficSequence, this.config.NodeHealth.QuarantineTrafficInterval) != 0)
+                if (Mod(trafficSequence, this.config.NodeHealth.QuarantinedNodeSamplingInterval) != 0)
                 {
                     return null;
                 }

--- a/AlternatorLiveNodes.cs
+++ b/AlternatorLiveNodes.cs
@@ -25,9 +25,13 @@ namespace ScyllaDB.Alternator
         private readonly AlternatorConfig config;
         private readonly HttpClient pollingHttpClient;
         private readonly bool ownsPollingHttpClient;
+        private readonly NodeHealthStore healthStore;
         private List<Uri> liveNodes;
         private int nextLiveNodeIndex;
+        private int nextQuarantinedNodeIndex;
+        private int nextQuarantineTrafficSequence;
         private long lastActivityTicks;
+        private long lastDownNodeProbeTicks;
         private bool started;
         private CancellationTokenSource? refreshCancellation;
         private Task? refreshTask;
@@ -112,6 +116,8 @@ namespace ScyllaDB.Alternator
             {
                 this.liveNodes.Add(node);
             }
+
+            this.healthStore = new NodeHealthStore(this.config.NodeHealth, this.initialNodes);
 
             try
             {
@@ -235,15 +241,27 @@ namespace ScyllaDB.Alternator
         public Uri NextAsUri()
         {
             this.MarkActivity();
-            var nodes = this.GetLiveNodes();
-            if (nodes.Count == 0)
+            var activeNodes = this.GetActiveNodesInternal();
+            if (activeNodes.Count == 0)
+            {
+                this.ProbeDownNodesOnce(CancellationToken.None);
+                activeNodes = this.GetActiveNodesInternal();
+            }
+
+            var quarantinedNode = this.SelectQuarantinedNode(activeNodes.Count == 0);
+            if (quarantinedNode != null)
+            {
+                return quarantinedNode;
+            }
+
+            if (activeNodes.Count == 0)
             {
                 throw new InvalidOperationException("No live nodes available");
             }
 
             var sequence = Interlocked.Increment(ref this.nextLiveNodeIndex) - 1;
-            var index = (int)(((sequence % nodes.Count) + nodes.Count) % nodes.Count);
-            return nodes[index];
+            var index = Mod(sequence, activeNodes.Count);
+            return activeNodes[index];
         }
 
         public IReadOnlyList<Uri> GetLiveNodes()
@@ -267,6 +285,26 @@ namespace ScyllaDB.Alternator
         public IReadOnlyList<Uri> GetQuarantinedNodes()
         {
             return this.GetQuarantinedNodesInternal().ToList().AsReadOnly();
+        }
+
+        public IReadOnlyList<Uri> GetDownNodes()
+        {
+            return this.GetDownNodesInternal().ToList().AsReadOnly();
+        }
+
+        public NodeHealthStatus? GetNodeStatus(Uri node)
+        {
+            return this.healthStore.GetNodeStatus(node);
+        }
+
+        public void ReportNodeResult(Uri node, NodeHealthObservation observation)
+        {
+            this.healthStore.ReportNodeResult(node, observation);
+        }
+
+        public Task<IReadOnlyList<Uri>> ProbeDownNodesAsync(CancellationToken cancellationToken = default)
+        {
+            return this.healthStore.ProbeDownNodesAsync(this.ProbeNodeAsync, cancellationToken);
         }
 
         public Uri NextAsUri(string? path, string? query)
@@ -429,18 +467,43 @@ namespace ScyllaDB.Alternator
         {
             return this.GetQuarantinedNodes();
         }
+
+        public IReadOnlyList<Uri> getDownNodes()
+        {
+            return this.GetDownNodes();
+        }
+
+        public NodeHealthStatus? getNodeStatus(Uri node)
+        {
+            return this.GetNodeStatus(node);
+        }
+
+        public void reportNodeResult(Uri node, NodeHealthObservation observation)
+        {
+            this.ReportNodeResult(node, observation);
+        }
+
+        public Task<IReadOnlyList<Uri>> probeDownNodesAsync()
+        {
+            return this.ProbeDownNodesAsync();
+        }
 #pragma warning restore SA1300, IDE1006
 
         internal Uri GetNodeForHash(long hash)
         {
             this.MarkActivity();
-            var nodes = this.GetLiveNodes();
+            var nodes = this.GetActiveNodesInternal();
+            if (nodes.Count == 0)
+            {
+                nodes = this.GetQuarantinedNodesInternal();
+            }
+
             if (nodes.Count == 0)
             {
                 throw new InvalidOperationException("No live nodes available");
             }
 
-            var index = (int)(((hash % nodes.Count) + nodes.Count) % nodes.Count);
+            var index = Mod(hash, nodes.Count);
             return nodes[index];
         }
 
@@ -477,12 +540,17 @@ namespace ScyllaDB.Alternator
 
         protected internal virtual IReadOnlyList<Uri> GetActiveNodesInternal()
         {
-            return this.GetLiveNodesInternal();
+            return this.healthStore.GetActiveNodes();
         }
 
         protected internal virtual IReadOnlyList<Uri> GetQuarantinedNodesInternal()
         {
-            return Array.Empty<Uri>();
+            return this.healthStore.GetQuarantinedNodes();
+        }
+
+        protected internal virtual IReadOnlyList<Uri> GetDownNodesInternal()
+        {
+            return this.healthStore.GetDownNodes();
         }
 
 #pragma warning disable SA1300, IDE1006
@@ -499,6 +567,11 @@ namespace ScyllaDB.Alternator
         protected internal virtual IReadOnlyList<Uri> getQuarantinedNodesInternal()
         {
             return this.GetQuarantinedNodesInternal();
+        }
+
+        protected internal virtual IReadOnlyList<Uri> getDownNodesInternal()
+        {
+            return this.GetDownNodesInternal();
         }
 #pragma warning restore SA1300, IDE1006
 
@@ -532,7 +605,8 @@ namespace ScyllaDB.Alternator
                 .WithConnectionTimeToLiveMs(config.ConnectionTimeToLiveMs)
                 .WithConnectionAcquisitionTimeoutMs(config.ConnectionAcquisitionTimeoutMs)
                 .WithConnectionTimeoutMs(config.ConnectionTimeoutMs)
-                .WithHttpClientTimeoutMs(config.HttpClientTimeoutMs);
+                .WithHttpClientTimeoutMs(config.HttpClientTimeoutMs)
+                .WithNodeHealth(config.NodeHealth);
 
             config.CopyHeaderOptimizationTo(builder);
             return builder.Build();
@@ -563,6 +637,11 @@ namespace ScyllaDB.Alternator
             }
 
             return builder.Uri;
+        }
+
+        private static int Mod(long value, int divisor)
+        {
+            return (int)(((value % divisor) + divisor) % divisor);
         }
 
         private static AlternatorConfig CreateLegacyConfig(
@@ -617,6 +696,7 @@ namespace ScyllaDB.Alternator
                     try
                     {
                         this.UpdateLiveNodes();
+                        this.ProbeDownNodesIfDue(cancellationToken);
                     }
                     catch (IOException e)
                     {
@@ -683,8 +763,15 @@ namespace ScyllaDB.Alternator
         private void SetLiveNodes(List<Uri> nodes)
         {
             this.liveNodesLock.EnterWriteLock();
-            this.liveNodes = nodes;
-            this.liveNodesLock.ExitWriteLock();
+            try
+            {
+                this.liveNodes = nodes;
+                this.healthStore.SetKnownNodes(nodes);
+            }
+            finally
+            {
+                this.liveNodesLock.ExitWriteLock();
+            }
         }
 
         private void UpdateLiveNodes()
@@ -784,40 +871,142 @@ namespace ScyllaDB.Alternator
             using var request = new HttpRequestMessage(HttpMethod.Get, uri);
             request.Headers.Host = uri.Authority;
             request.Headers.Connection.Add("keep-alive");
-            using var response = this.pollingHttpClient.SendAsync(request).Result;
-            if (!response.IsSuccessStatusCode)
+            var started = Stopwatch.GetTimestamp();
+            HttpResponseMessage response;
+            try
             {
-                return new List<Uri>();
+                response = this.pollingHttpClient.SendAsync(request).Result;
+            }
+            catch (Exception)
+            {
+                this.ReportNodeResult(uri, NodeHealthObservation.ConnectionFailure);
+                throw;
             }
 
-            var responseBody = StreamToString(response.Content.ReadAsStreamAsync().Result);
-            var list = JsonSerializer.Deserialize<List<string>>(responseBody) ?? new List<string>();
-            var newHosts = new List<Uri>();
-            foreach (var host in list)
+            using (response)
             {
-                if (string.IsNullOrEmpty(host))
+                this.ReportNodeResult(
+                    uri,
+                    NodeHealthReportingHttpMessageHandler.ObservationFromResponse(
+                        response,
+                        Stopwatch.GetElapsedTime(started),
+                        this.config.NodeHealth));
+
+                if (!response.IsSuccessStatusCode)
                 {
-                    continue;
+                    return new List<Uri>();
                 }
 
-                var trimmedHost = host.Trim();
-                try
+                var responseBody = StreamToString(response.Content.ReadAsStreamAsync().Result);
+                var list = JsonSerializer.Deserialize<List<string>>(responseBody) ?? new List<string>();
+                var newHosts = new List<Uri>();
+                foreach (var host in list)
                 {
-                    newHosts.Add(this.HostToUri(trimmedHost));
+                    if (string.IsNullOrEmpty(host))
+                    {
+                        continue;
+                    }
+
+                    var trimmedHost = host.Trim();
+                    try
+                    {
+                        newHosts.Add(this.HostToUri(trimmedHost));
+                    }
+                    catch (UriFormatException e)
+                    {
+                        Logger.Error(e, $"Invalid host: {trimmedHost}");
+                    }
                 }
-                catch (UriFormatException e)
-                {
-                    Logger.Error(e, $"Invalid host: {trimmedHost}");
-                }
+
+                return newHosts;
             }
-
-            return newHosts;
         }
 
         private Uri NextAsLocalNodesUri()
         {
             var query = this.config.RoutingScope.LocalNodesQuery;
             return this.NextAsUri("/localnodes", string.IsNullOrEmpty(query) ? null : query);
+        }
+
+        private Uri? SelectQuarantinedNode(bool activeNodesEmpty)
+        {
+            var quarantinedNodes = this.GetQuarantinedNodesInternal();
+            if (quarantinedNodes.Count == 0)
+            {
+                return null;
+            }
+
+            if (!activeNodesEmpty)
+            {
+                var trafficSequence = Interlocked.Increment(ref this.nextQuarantineTrafficSequence);
+                if (Mod(trafficSequence, this.config.NodeHealth.QuarantineTrafficInterval) != 0)
+                {
+                    return null;
+                }
+            }
+
+            var sequence = Interlocked.Increment(ref this.nextQuarantinedNodeIndex) - 1;
+            return quarantinedNodes[Mod(sequence, quarantinedNodes.Count)];
+        }
+
+        private void ProbeDownNodesOnce(CancellationToken cancellationToken)
+        {
+            try
+            {
+                this.ProbeDownNodesAsync(cancellationToken).GetAwaiter().GetResult();
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+        }
+
+        private void ProbeDownNodesIfDue(CancellationToken cancellationToken)
+        {
+            if (this.config.NodeHealth.Disabled || this.GetDownNodesInternal().Count == 0)
+            {
+                return;
+            }
+
+            var now = DateTimeOffset.UtcNow.Ticks;
+            var lastProbe = Interlocked.Read(ref this.lastDownNodeProbeTicks);
+            var probePeriod = TimeSpan.FromMilliseconds(this.config.NodeHealth.DownNodeProbePeriodMs);
+            if (lastProbe != 0 && new DateTimeOffset(now, TimeSpan.Zero) - new DateTimeOffset(lastProbe, TimeSpan.Zero) < probePeriod)
+            {
+                return;
+            }
+
+            Interlocked.Exchange(ref this.lastDownNodeProbeTicks, now);
+            this.ProbeDownNodesOnce(cancellationToken);
+        }
+
+        private async Task<NodeHealthObservation?> ProbeNodeAsync(
+            Uri node,
+            NodeHealthStatus status,
+            CancellationToken cancellationToken)
+        {
+            var query = this.config.RoutingScope.LocalNodesQuery;
+            var requestQuery = string.IsNullOrEmpty(query) ? null : query;
+            var uri = BuildUri(node, "/localnodes", requestQuery);
+            using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+            request.Headers.Host = uri.Authority;
+            request.Headers.Connection.Add("keep-alive");
+            var started = Stopwatch.GetTimestamp();
+            try
+            {
+                using var response = await this.pollingHttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                return NodeHealthReportingHttpMessageHandler.ObservationFromResponse(
+                    response,
+                    Stopwatch.GetElapsedTime(started),
+                    this.config.NodeHealth);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return null;
+            }
+            catch (Exception)
+            {
+                return NodeHealthObservation.ConnectionFailure;
+            }
         }
 
         private List<Uri> MergeWithInitialNodes(IEnumerable<Uri> nodes)

--- a/HelperOptions.cs
+++ b/HelperOptions.cs
@@ -94,6 +94,8 @@ namespace ScyllaDB.Alternator
 
         public KeyRouteAffinityConfig? KeyRouteAffinityConfig { get; set; }
 
+        public NodeHealthStoreConfig NodeHealth { get; set; } = new NodeHealthStoreConfig();
+
         internal AlternatorConfig ToAlternatorConfig()
         {
             var builder = AlternatorConfig.Builder()
@@ -114,7 +116,8 @@ namespace ScyllaDB.Alternator
                 .WithConnectionAcquisitionTimeoutMs(this.ConnectionAcquisitionTimeoutMs)
                 .WithConnectionTimeoutMs(this.ConnectionTimeoutMs)
                 .WithHttpClientTimeoutMs(this.HttpClientTimeoutMs)
-                .WithTlsConfig(this.TlsConfig);
+                .WithTlsConfig(this.TlsConfig)
+                .WithNodeHealth(this.NodeHealth);
 
             if (this.CustomOptimizeHeaders != null)
             {

--- a/HelperOptionsBuilder.cs
+++ b/HelperOptionsBuilder.cs
@@ -307,6 +307,12 @@ namespace ScyllaDB.Alternator
             return this;
         }
 
+        public HelperOptionsBuilder WithNodeHealth(NodeHealthStoreConfig? config)
+        {
+            this.options.NodeHealth = NodeHealthStoreConfig.Normalize(config);
+            return this;
+        }
+
         /// <summary>
         /// Sets the initial nodes, schema and port for connecting to ScyllaDB Alternator from provided Uri.
         /// </summary>

--- a/NodeHealthObservation.cs
+++ b/NodeHealthObservation.cs
@@ -1,0 +1,14 @@
+// <copyright file="NodeHealthObservation.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    public enum NodeHealthObservation
+    {
+        Success,
+        ServerError,
+        RequestTimeout,
+        ConnectionFailure,
+    }
+}

--- a/NodeHealthReportingHttpMessageHandler.cs
+++ b/NodeHealthReportingHttpMessageHandler.cs
@@ -1,0 +1,77 @@
+// <copyright file="NodeHealthReportingHttpMessageHandler.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    using System.Diagnostics;
+    using System.Net.Http;
+
+    internal sealed class NodeHealthReportingHttpMessageHandler : DelegatingHandler
+    {
+        private readonly AlternatorLiveNodes liveNodes;
+        private readonly NodeHealthStoreConfig healthConfig;
+
+        internal NodeHealthReportingHttpMessageHandler(
+            HttpMessageHandler innerHandler,
+            AlternatorLiveNodes liveNodes,
+            NodeHealthStoreConfig healthConfig)
+            : base(innerHandler)
+        {
+            this.liveNodes = liveNodes ?? throw new ArgumentNullException(nameof(liveNodes));
+            this.healthConfig = NodeHealthStoreConfig.Normalize(healthConfig);
+        }
+
+        internal static NodeHealthObservation ObservationFromResponse(
+            HttpResponseMessage response,
+            TimeSpan elapsed,
+            NodeHealthStoreConfig healthConfig)
+        {
+            if ((int)response.StatusCode < 500)
+            {
+                return NodeHealthObservation.Success;
+            }
+
+            var timeoutThresholdMs = NodeHealthStoreConfig.Normalize(healthConfig).ServerRequestTimeoutThresholdMs;
+            if (timeoutThresholdMs > 0 && elapsed >= TimeSpan.FromMilliseconds(timeoutThresholdMs))
+            {
+                return NodeHealthObservation.RequestTimeout;
+            }
+
+            return NodeHealthObservation.ServerError;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var node = TryExtractAlternatorNode(request.RequestUri);
+            var started = Stopwatch.GetTimestamp();
+            try
+            {
+                var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                if (node != null)
+                {
+                    this.liveNodes.ReportNodeResult(
+                        node,
+                        ObservationFromResponse(response, Stopwatch.GetElapsedTime(started), this.healthConfig));
+                }
+
+                return response;
+            }
+            catch (Exception) when (node != null && !cancellationToken.IsCancellationRequested)
+            {
+                this.liveNodes.ReportNodeResult(node, NodeHealthObservation.ConnectionFailure);
+                throw;
+            }
+        }
+
+        private static Uri? TryExtractAlternatorNode(Uri? requestUri)
+        {
+            if (requestUri == null || !requestUri.IsAbsoluteUri)
+            {
+                return null;
+            }
+
+            return new UriBuilder(requestUri.Scheme, requestUri.Host, requestUri.Port).Uri;
+        }
+    }
+}

--- a/NodeHealthState.cs
+++ b/NodeHealthState.cs
@@ -1,0 +1,13 @@
+// <copyright file="NodeHealthState.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    public enum NodeHealthState
+    {
+        Active,
+        Quarantined,
+        Down,
+    }
+}

--- a/NodeHealthStatus.cs
+++ b/NodeHealthStatus.cs
@@ -1,0 +1,28 @@
+// <copyright file="NodeHealthStatus.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    public sealed class NodeHealthStatus
+    {
+        public NodeHealthState State { get; internal set; } = NodeHealthState.Active;
+
+        public int ConsecutiveServerErrors { get; internal set; }
+
+        public int ConsecutiveSuccesses { get; internal set; }
+
+        public DateTimeOffset UpdatedAt { get; internal set; } = DateTimeOffset.UtcNow;
+
+        internal NodeHealthStatus Copy()
+        {
+            return new NodeHealthStatus
+            {
+                State = this.State,
+                ConsecutiveServerErrors = this.ConsecutiveServerErrors,
+                ConsecutiveSuccesses = this.ConsecutiveSuccesses,
+                UpdatedAt = this.UpdatedAt,
+            };
+        }
+    }
+}

--- a/NodeHealthStore.cs
+++ b/NodeHealthStore.cs
@@ -1,0 +1,276 @@
+// <copyright file="NodeHealthStore.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    internal sealed class NodeHealthStore
+    {
+        private readonly object sync = new object();
+        private readonly NodeHealthStoreConfig config;
+        private readonly Dictionary<Uri, NodeHealthStatus> statuses = new Dictionary<Uri, NodeHealthStatus>();
+
+        internal NodeHealthStore(NodeHealthStoreConfig config, IEnumerable<Uri> initialNodes)
+        {
+            this.config = NodeHealthStoreConfig.Normalize(config);
+            if (initialNodes == null)
+            {
+                throw new ArgumentNullException(nameof(initialNodes));
+            }
+
+            foreach (var node in initialNodes)
+            {
+                this.AddNode(node);
+            }
+        }
+
+        internal IReadOnlyList<Uri> GetActiveNodes()
+        {
+            if (this.config.Disabled)
+            {
+                return this.GetNodes(_ => true);
+            }
+
+            return this.GetNodes(status => status.State == NodeHealthState.Active);
+        }
+
+        internal IReadOnlyList<Uri> GetQuarantinedNodes()
+        {
+            if (this.config.Disabled)
+            {
+                return Array.Empty<Uri>();
+            }
+
+            return this.GetNodes(status => status.State == NodeHealthState.Quarantined);
+        }
+
+        internal IReadOnlyList<Uri> GetDownNodes()
+        {
+            if (this.config.Disabled)
+            {
+                return Array.Empty<Uri>();
+            }
+
+            return this.GetNodes(status => status.State == NodeHealthState.Down);
+        }
+
+        internal NodeHealthStatus? GetNodeStatus(Uri node)
+        {
+            if (node == null)
+            {
+                throw new ArgumentNullException(nameof(node));
+            }
+
+            var normalizedNode = NormalizeNode(node);
+            lock (this.sync)
+            {
+                return this.statuses.TryGetValue(normalizedNode, out var status)
+                    ? status.Copy()
+                    : null;
+            }
+        }
+
+        internal void AddNode(Uri node)
+        {
+            if (node == null)
+            {
+                throw new ArgumentNullException(nameof(node));
+            }
+
+            var normalizedNode = NormalizeNode(node);
+            lock (this.sync)
+            {
+                this.statuses.TryAdd(normalizedNode, new NodeHealthStatus());
+            }
+        }
+
+        internal void RemoveNode(Uri node)
+        {
+            if (node == null)
+            {
+                throw new ArgumentNullException(nameof(node));
+            }
+
+            var normalizedNode = NormalizeNode(node);
+            lock (this.sync)
+            {
+                this.statuses.Remove(normalizedNode);
+            }
+        }
+
+        internal void SetKnownNodes(IEnumerable<Uri> nodes)
+        {
+            if (nodes == null)
+            {
+                throw new ArgumentNullException(nameof(nodes));
+            }
+
+            var normalizedNodes = new HashSet<Uri>(nodes.Select(NormalizeNode));
+            lock (this.sync)
+            {
+                foreach (var node in normalizedNodes)
+                {
+                    this.statuses.TryAdd(node, new NodeHealthStatus());
+                }
+
+                var removedNodes = this.statuses.Keys
+                    .Where(node => !normalizedNodes.Contains(node))
+                    .ToList();
+                foreach (var removedNode in removedNodes)
+                {
+                    this.statuses.Remove(removedNode);
+                }
+            }
+        }
+
+        internal void ReportNodeResult(Uri node, NodeHealthObservation observation)
+        {
+            if (node == null)
+            {
+                throw new ArgumentNullException(nameof(node));
+            }
+
+            if (this.config.Disabled)
+            {
+                return;
+            }
+
+            var normalizedNode = NormalizeNode(node);
+            lock (this.sync)
+            {
+                if (!this.statuses.TryGetValue(normalizedNode, out var status))
+                {
+                    return;
+                }
+
+                this.ApplyObservation(status, observation);
+            }
+        }
+
+        internal async Task<IReadOnlyList<Uri>> ProbeDownNodesAsync(
+            Func<Uri, NodeHealthStatus, CancellationToken, Task<NodeHealthObservation?>> probe,
+            CancellationToken cancellationToken)
+        {
+            if (probe == null)
+            {
+                throw new ArgumentNullException(nameof(probe));
+            }
+
+            if (this.config.Disabled)
+            {
+                return Array.Empty<Uri>();
+            }
+
+            var downNodes = this.GetDownNodeSnapshot();
+            var changedNodes = new List<Uri>();
+            foreach (var item in downNodes)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var observation = await probe(item.Node, item.Status, cancellationToken).ConfigureAwait(false);
+                if (observation == null)
+                {
+                    continue;
+                }
+
+                this.ReportNodeResult(item.Node, observation.Value);
+                var updatedStatus = this.GetNodeStatus(item.Node);
+                if (updatedStatus?.State != NodeHealthState.Down)
+                {
+                    changedNodes.Add(item.Node);
+                }
+            }
+
+            return SortNodes(changedNodes).AsReadOnly();
+        }
+
+        private static Uri NormalizeNode(Uri node)
+        {
+            if (!node.IsAbsoluteUri)
+            {
+                throw new ArgumentException("node URI must be absolute", nameof(node));
+            }
+
+            return new UriBuilder(node.Scheme, node.Host, node.Port).Uri;
+        }
+
+        private static List<Uri> SortNodes(IEnumerable<Uri> nodes)
+        {
+            var sorted = nodes.ToList();
+            sorted.Sort((left, right) => string.Compare(left.ToString(), right.ToString(), StringComparison.Ordinal));
+            return sorted;
+        }
+
+        private IReadOnlyList<Uri> GetNodes(Func<NodeHealthStatus, bool> predicate)
+        {
+            lock (this.sync)
+            {
+                return SortNodes(this.statuses
+                    .Where(item => predicate(item.Value))
+                    .Select(item => item.Key))
+                    .AsReadOnly();
+            }
+        }
+
+        private List<(Uri Node, NodeHealthStatus Status)> GetDownNodeSnapshot()
+        {
+            lock (this.sync)
+            {
+                return this.statuses
+                    .Where(item => item.Value.State == NodeHealthState.Down)
+                    .Select(item => (item.Key, item.Value.Copy()))
+                    .ToList();
+            }
+        }
+
+        private void ApplyObservation(NodeHealthStatus status, NodeHealthObservation observation)
+        {
+            switch (observation)
+            {
+                case NodeHealthObservation.ConnectionFailure:
+                    status.State = NodeHealthState.Down;
+                    status.ConsecutiveServerErrors = this.config.ConsecutiveServerErrorThreshold;
+                    status.ConsecutiveSuccesses = 0;
+                    break;
+                case NodeHealthObservation.ServerError:
+                    status.ConsecutiveServerErrors++;
+                    status.ConsecutiveSuccesses = 0;
+                    if (status.ConsecutiveServerErrors >= this.config.ConsecutiveServerErrorThreshold)
+                    {
+                        status.State = NodeHealthState.Down;
+                    }
+
+                    break;
+                case NodeHealthObservation.RequestTimeout:
+                    break;
+                case NodeHealthObservation.Success:
+                    status.ConsecutiveServerErrors = 0;
+                    if (status.State == NodeHealthState.Down)
+                    {
+                        status.State = NodeHealthState.Quarantined;
+                        status.ConsecutiveSuccesses = 1;
+                    }
+                    else if (status.State == NodeHealthState.Quarantined)
+                    {
+                        status.ConsecutiveSuccesses++;
+                    }
+                    else
+                    {
+                        status.ConsecutiveSuccesses = Math.Min(
+                            this.config.QuarantineSuccessThreshold,
+                            status.ConsecutiveSuccesses + 1);
+                    }
+
+                    if (status.State == NodeHealthState.Quarantined
+                        && status.ConsecutiveSuccesses >= this.config.QuarantineSuccessThreshold)
+                    {
+                        status.State = NodeHealthState.Active;
+                        status.ConsecutiveSuccesses = this.config.QuarantineSuccessThreshold;
+                    }
+
+                    break;
+            }
+
+            status.UpdatedAt = DateTimeOffset.UtcNow;
+        }
+    }
+}

--- a/NodeHealthStoreConfig.cs
+++ b/NodeHealthStoreConfig.cs
@@ -15,8 +15,8 @@ namespace ScyllaDB.Alternator
         public long DownNodeProbePeriodMs { get; init; } =
             AlternatorConfig.DefaultDownNodeProbePeriodMs;
 
-        public int QuarantineTrafficInterval { get; init; } =
-            AlternatorConfig.DefaultQuarantineTrafficInterval;
+        public int QuarantinedNodeSamplingInterval { get; init; } =
+            AlternatorConfig.DefaultQuarantinedNodeSamplingInterval;
 
         public long ServerRequestTimeoutThresholdMs { get; init; } =
             AlternatorConfig.DefaultServerRequestTimeoutThresholdMs;
@@ -43,7 +43,7 @@ namespace ScyllaDB.Alternator
                 ConsecutiveServerErrorThreshold = Math.Max(1, config.ConsecutiveServerErrorThreshold),
                 QuarantineSuccessThreshold = Math.Max(1, config.QuarantineSuccessThreshold),
                 DownNodeProbePeriodMs = Math.Max(1, config.DownNodeProbePeriodMs),
-                QuarantineTrafficInterval = Math.Max(1, config.QuarantineTrafficInterval),
+                QuarantinedNodeSamplingInterval = Math.Max(1, config.QuarantinedNodeSamplingInterval),
                 ServerRequestTimeoutThresholdMs = config.ServerRequestTimeoutThresholdMs,
                 Disabled = config.Disabled,
             };

--- a/NodeHealthStoreConfig.cs
+++ b/NodeHealthStoreConfig.cs
@@ -1,0 +1,52 @@
+// <copyright file="NodeHealthStoreConfig.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    public sealed class NodeHealthStoreConfig
+    {
+        public int ConsecutiveServerErrorThreshold { get; init; } =
+            AlternatorConfig.DefaultConsecutiveServerErrorThreshold;
+
+        public int QuarantineSuccessThreshold { get; init; } =
+            AlternatorConfig.DefaultQuarantineSuccessThreshold;
+
+        public long DownNodeProbePeriodMs { get; init; } =
+            AlternatorConfig.DefaultDownNodeProbePeriodMs;
+
+        public int QuarantineTrafficInterval { get; init; } =
+            AlternatorConfig.DefaultQuarantineTrafficInterval;
+
+        public long ServerRequestTimeoutThresholdMs { get; init; } =
+            AlternatorConfig.DefaultServerRequestTimeoutThresholdMs;
+
+        public bool Disabled { get; init; }
+
+        public static NodeHealthStoreConfigBuilder Builder()
+        {
+            return new NodeHealthStoreConfigBuilder();
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public static NodeHealthStoreConfigBuilder builder()
+        {
+            return Builder();
+        }
+#pragma warning restore SA1300, IDE1006
+
+        internal static NodeHealthStoreConfig Normalize(NodeHealthStoreConfig? config)
+        {
+            config ??= new NodeHealthStoreConfig();
+            return new NodeHealthStoreConfig
+            {
+                ConsecutiveServerErrorThreshold = Math.Max(1, config.ConsecutiveServerErrorThreshold),
+                QuarantineSuccessThreshold = Math.Max(1, config.QuarantineSuccessThreshold),
+                DownNodeProbePeriodMs = Math.Max(1, config.DownNodeProbePeriodMs),
+                QuarantineTrafficInterval = Math.Max(1, config.QuarantineTrafficInterval),
+                ServerRequestTimeoutThresholdMs = config.ServerRequestTimeoutThresholdMs,
+                Disabled = config.Disabled,
+            };
+        }
+    }
+}

--- a/NodeHealthStoreConfigBuilder.cs
+++ b/NodeHealthStoreConfigBuilder.cs
@@ -1,0 +1,112 @@
+// <copyright file="NodeHealthStoreConfigBuilder.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    public sealed class NodeHealthStoreConfigBuilder
+    {
+        private int consecutiveServerErrorThreshold = AlternatorConfig.DefaultConsecutiveServerErrorThreshold;
+        private int quarantineSuccessThreshold = AlternatorConfig.DefaultQuarantineSuccessThreshold;
+        private long downNodeProbePeriodMs = AlternatorConfig.DefaultDownNodeProbePeriodMs;
+        private int quarantineTrafficInterval = AlternatorConfig.DefaultQuarantineTrafficInterval;
+        private long serverRequestTimeoutThresholdMs = AlternatorConfig.DefaultServerRequestTimeoutThresholdMs;
+        private bool isDisabled;
+
+        public NodeHealthStoreConfigBuilder WithConsecutiveServerErrorThreshold(int threshold)
+        {
+            this.consecutiveServerErrorThreshold = threshold;
+            return this;
+        }
+
+        public NodeHealthStoreConfigBuilder WithQuarantineSuccessThreshold(int threshold)
+        {
+            this.quarantineSuccessThreshold = threshold;
+            return this;
+        }
+
+        public NodeHealthStoreConfigBuilder WithDownNodeProbePeriodMs(long periodMs)
+        {
+            this.downNodeProbePeriodMs = periodMs;
+            return this;
+        }
+
+        public NodeHealthStoreConfigBuilder WithQuarantineTrafficInterval(int interval)
+        {
+            this.quarantineTrafficInterval = interval;
+            return this;
+        }
+
+        public NodeHealthStoreConfigBuilder WithServerRequestTimeoutThresholdMs(long thresholdMs)
+        {
+            this.serverRequestTimeoutThresholdMs = thresholdMs;
+            return this;
+        }
+
+        public NodeHealthStoreConfigBuilder WithDisabled(bool disabled)
+        {
+            this.isDisabled = disabled;
+            return this;
+        }
+
+        public NodeHealthStoreConfigBuilder Disabled()
+        {
+            return this.WithDisabled(true);
+        }
+
+        public NodeHealthStoreConfig Build()
+        {
+            return NodeHealthStoreConfig.Normalize(new NodeHealthStoreConfig
+            {
+                ConsecutiveServerErrorThreshold = this.consecutiveServerErrorThreshold,
+                QuarantineSuccessThreshold = this.quarantineSuccessThreshold,
+                DownNodeProbePeriodMs = this.downNodeProbePeriodMs,
+                QuarantineTrafficInterval = this.quarantineTrafficInterval,
+                ServerRequestTimeoutThresholdMs = this.serverRequestTimeoutThresholdMs,
+                Disabled = this.isDisabled,
+            });
+        }
+
+#pragma warning disable SA1300, IDE1006
+        public NodeHealthStoreConfigBuilder withConsecutiveServerErrorThreshold(int threshold)
+        {
+            return this.WithConsecutiveServerErrorThreshold(threshold);
+        }
+
+        public NodeHealthStoreConfigBuilder withQuarantineSuccessThreshold(int threshold)
+        {
+            return this.WithQuarantineSuccessThreshold(threshold);
+        }
+
+        public NodeHealthStoreConfigBuilder withDownNodeProbePeriodMs(long periodMs)
+        {
+            return this.WithDownNodeProbePeriodMs(periodMs);
+        }
+
+        public NodeHealthStoreConfigBuilder withQuarantineTrafficInterval(int interval)
+        {
+            return this.WithQuarantineTrafficInterval(interval);
+        }
+
+        public NodeHealthStoreConfigBuilder withServerRequestTimeoutThresholdMs(long thresholdMs)
+        {
+            return this.WithServerRequestTimeoutThresholdMs(thresholdMs);
+        }
+
+        public NodeHealthStoreConfigBuilder withDisabled(bool disabled)
+        {
+            return this.WithDisabled(disabled);
+        }
+
+        public NodeHealthStoreConfigBuilder disabled()
+        {
+            return this.Disabled();
+        }
+
+        public NodeHealthStoreConfig build()
+        {
+            return this.Build();
+        }
+#pragma warning restore SA1300, IDE1006
+    }
+}

--- a/NodeHealthStoreConfigBuilder.cs
+++ b/NodeHealthStoreConfigBuilder.cs
@@ -9,7 +9,7 @@ namespace ScyllaDB.Alternator
         private int consecutiveServerErrorThreshold = AlternatorConfig.DefaultConsecutiveServerErrorThreshold;
         private int quarantineSuccessThreshold = AlternatorConfig.DefaultQuarantineSuccessThreshold;
         private long downNodeProbePeriodMs = AlternatorConfig.DefaultDownNodeProbePeriodMs;
-        private int quarantineTrafficInterval = AlternatorConfig.DefaultQuarantineTrafficInterval;
+        private int quarantinedNodeSamplingInterval = AlternatorConfig.DefaultQuarantinedNodeSamplingInterval;
         private long serverRequestTimeoutThresholdMs = AlternatorConfig.DefaultServerRequestTimeoutThresholdMs;
         private bool isDisabled;
 
@@ -31,9 +31,9 @@ namespace ScyllaDB.Alternator
             return this;
         }
 
-        public NodeHealthStoreConfigBuilder WithQuarantineTrafficInterval(int interval)
+        public NodeHealthStoreConfigBuilder WithQuarantinedNodeSamplingInterval(int interval)
         {
-            this.quarantineTrafficInterval = interval;
+            this.quarantinedNodeSamplingInterval = interval;
             return this;
         }
 
@@ -61,7 +61,7 @@ namespace ScyllaDB.Alternator
                 ConsecutiveServerErrorThreshold = this.consecutiveServerErrorThreshold,
                 QuarantineSuccessThreshold = this.quarantineSuccessThreshold,
                 DownNodeProbePeriodMs = this.downNodeProbePeriodMs,
-                QuarantineTrafficInterval = this.quarantineTrafficInterval,
+                QuarantinedNodeSamplingInterval = this.quarantinedNodeSamplingInterval,
                 ServerRequestTimeoutThresholdMs = this.serverRequestTimeoutThresholdMs,
                 Disabled = this.isDisabled,
             });
@@ -83,9 +83,9 @@ namespace ScyllaDB.Alternator
             return this.WithDownNodeProbePeriodMs(periodMs);
         }
 
-        public NodeHealthStoreConfigBuilder withQuarantineTrafficInterval(int interval)
+        public NodeHealthStoreConfigBuilder withQuarantinedNodeSamplingInterval(int interval)
         {
-            return this.WithQuarantineTrafficInterval(interval);
+            return this.WithQuarantinedNodeSamplingInterval(interval);
         }
 
         public NodeHealthStoreConfigBuilder withServerRequestTimeoutThresholdMs(long thresholdMs)

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ client builder:
 
 ```csharp
 var nodeHealth = NodeHealthStoreConfig.builder()
-    .withConsecutiveServerErrorThreshold(3)
-    .withQuarantineSuccessThreshold(3)
-    .withQuarantineTrafficInterval(10)
+    .withConsecutiveServerErrorThreshold(10)
+    .withQuarantineSuccessThreshold(10)
+    .withQuarantinedNodeSamplingInterval(10)
     .withDownNodeProbePeriodMs(30000)
     .withServerRequestTimeoutThresholdMs(9000)
     .build();

--- a/README.md
+++ b/README.md
@@ -121,6 +121,35 @@ AmazonDynamoDBClient client = AlternatorDynamoDBClient.Create(
     rack: "rack1");
 ```
 
+## Node Health
+
+Node health is enabled by default. Nodes move between active, quarantined, and
+down states based on request outcomes. Down nodes are skipped for normal routing,
+quarantined nodes receive limited recovery traffic, and long-running HTTP 5xx
+responses can be treated as server-side request timeouts rather than node
+failures.
+
+Tune health behavior by building a node-health config and passing it once to the
+client builder:
+
+```csharp
+var nodeHealth = NodeHealthStoreConfig.builder()
+    .withConsecutiveServerErrorThreshold(3)
+    .withQuarantineSuccessThreshold(3)
+    .withQuarantineTrafficInterval(10)
+    .withDownNodeProbePeriodMs(30000)
+    .withServerRequestTimeoutThresholdMs(9000)
+    .build();
+
+AmazonDynamoDBClient client = AlternatorDynamoDBClient.builder()
+    .endpointOverride("http://127.0.0.1:8000")
+    .withNodeHealth(nodeHealth)
+    .build();
+```
+
+Use `disabled()` on the node-health config builder to keep all known nodes in the
+active set.
+
 ## HTTP Client Configuration
 
 The .NET SDK uses `AmazonDynamoDBConfig.HttpClientFactory` for transport customization. The Alternator builder configures an internal factory so TLS, header filtering, compression, connection pool tuning, and endpoint routing stay active.

--- a/UnitTests/NodeHealthUnitTests.cs
+++ b/UnitTests/NodeHealthUnitTests.cs
@@ -91,7 +91,7 @@ namespace ScyllaDB.Alternator
             var liveNodes = CreateLiveNodes(
                 new[] { "node1.example.com", "node2.example.com" },
                 builder => builder
-                    .withQuarantineTrafficInterval(2)
+                    .withQuarantinedNodeSamplingInterval(2)
                     .withQuarantineSuccessThreshold(3),
                 pollingHttpClient);
             var activeNode = Node("node1.example.com");
@@ -217,7 +217,7 @@ namespace ScyllaDB.Alternator
                 .withConsecutiveServerErrorThreshold(0)
                 .withQuarantineSuccessThreshold(0)
                 .withDownNodeProbePeriodMs(0)
-                .withQuarantineTrafficInterval(0)
+                .withQuarantinedNodeSamplingInterval(0)
                 .withServerRequestTimeoutThresholdMs(0)
                 .disabled()
                 .build();
@@ -228,7 +228,7 @@ namespace ScyllaDB.Alternator
             Assert.That(config.getNodeHealth().ConsecutiveServerErrorThreshold, Is.EqualTo(1));
             Assert.That(config.getNodeHealth().QuarantineSuccessThreshold, Is.EqualTo(1));
             Assert.That(config.getNodeHealth().DownNodeProbePeriodMs, Is.EqualTo(1));
-            Assert.That(config.getNodeHealth().QuarantineTrafficInterval, Is.EqualTo(1));
+            Assert.That(config.getNodeHealth().QuarantinedNodeSamplingInterval, Is.EqualTo(1));
             Assert.That(config.getNodeHealth().ServerRequestTimeoutThresholdMs, Is.EqualTo(0));
             Assert.That(config.getNodeHealth().Disabled, Is.True);
         }

--- a/UnitTests/NodeHealthUnitTests.cs
+++ b/UnitTests/NodeHealthUnitTests.cs
@@ -1,0 +1,361 @@
+// <copyright file="NodeHealthUnitTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace ScyllaDB.Alternator
+{
+    using System.Net;
+    using ScyllaDB.Alternator.Routing;
+
+    [TestFixture]
+    [Category("Unit")]
+    public class NodeHealthUnitTests
+    {
+        [Test]
+        public void ConnectionFailureMarksNodeDownAndSuccessPromotesThroughQuarantineTest()
+        {
+            using var pollingHttpClient = CreatePollingClient();
+            var liveNodes = CreateLiveNodes(
+                new[] { "node1.example.com" },
+                builder => builder.withQuarantineSuccessThreshold(2),
+                pollingHttpClient);
+            var node = Node("node1.example.com");
+
+            liveNodes.reportNodeResult(node, NodeHealthObservation.ConnectionFailure);
+
+            Assert.That(liveNodes.getActiveNodes(), Is.Empty);
+            Assert.That(liveNodes.getQuarantinedNodes(), Is.Empty);
+            Assert.That(liveNodes.getDownNodes(), Is.EqualTo(new[] { node }));
+            Assert.That(liveNodes.getNodeStatus(node) !.State, Is.EqualTo(NodeHealthState.Down));
+
+            liveNodes.reportNodeResult(node, NodeHealthObservation.Success);
+
+            Assert.That(liveNodes.getQuarantinedNodes(), Is.EqualTo(new[] { node }));
+            Assert.That(liveNodes.getNodeStatus(node) !.ConsecutiveSuccesses, Is.EqualTo(1));
+
+            liveNodes.reportNodeResult(node, NodeHealthObservation.Success);
+
+            Assert.That(liveNodes.getActiveNodes(), Is.EqualTo(new[] { node }));
+            Assert.That(liveNodes.getQuarantinedNodes(), Is.Empty);
+            Assert.That(liveNodes.getNodeStatus(node) !.State, Is.EqualTo(NodeHealthState.Active));
+        }
+
+        [Test]
+        public void ServerErrorsRespectThresholdAndRequestTimeoutIsNeutralTest()
+        {
+            using var pollingHttpClient = CreatePollingClient();
+            var liveNodes = CreateLiveNodes(
+                new[] { "node1.example.com" },
+                builder => builder.withConsecutiveServerErrorThreshold(2),
+                pollingHttpClient);
+            var node = Node("node1.example.com");
+
+            liveNodes.reportNodeResult(node, NodeHealthObservation.ServerError);
+            liveNodes.reportNodeResult(node, NodeHealthObservation.RequestTimeout);
+
+            var activeStatus = liveNodes.getNodeStatus(node) !;
+            Assert.That(activeStatus.State, Is.EqualTo(NodeHealthState.Active));
+            Assert.That(activeStatus.ConsecutiveServerErrors, Is.EqualTo(1));
+
+            liveNodes.reportNodeResult(node, NodeHealthObservation.ServerError);
+
+            var downStatus = liveNodes.getNodeStatus(node) !;
+            Assert.That(downStatus.State, Is.EqualTo(NodeHealthState.Down));
+            Assert.That(downStatus.ConsecutiveServerErrors, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void DisabledNodeHealthKeepsEveryKnownNodeActiveTest()
+        {
+            using var pollingHttpClient = CreatePollingClient();
+            var liveNodes = CreateLiveNodes(
+                new[] { "node1.example.com", "node2.example.com" },
+                builder => builder.withDisabled(true),
+                pollingHttpClient);
+            var node = Node("node1.example.com");
+
+            liveNodes.reportNodeResult(node, NodeHealthObservation.ConnectionFailure);
+            liveNodes.reportNodeResult(node, NodeHealthObservation.ServerError);
+
+            Assert.That(
+                liveNodes.getActiveNodes(),
+                Is.EqualTo(new[] { Node("node1.example.com"), Node("node2.example.com") }));
+            Assert.That(liveNodes.getQuarantinedNodes(), Is.Empty);
+            Assert.That(liveNodes.getDownNodes(), Is.Empty);
+        }
+
+        [Test]
+        public void NextAsUriUsesActiveNodesAndSamplesQuarantinedNodesTest()
+        {
+            using var pollingHttpClient = CreatePollingClient();
+            var liveNodes = CreateLiveNodes(
+                new[] { "node1.example.com", "node2.example.com" },
+                builder => builder
+                    .withQuarantineTrafficInterval(2)
+                    .withQuarantineSuccessThreshold(3),
+                pollingHttpClient);
+            var activeNode = Node("node1.example.com");
+            var quarantinedNode = Node("node2.example.com");
+            liveNodes.reportNodeResult(quarantinedNode, NodeHealthObservation.ConnectionFailure);
+            liveNodes.reportNodeResult(quarantinedNode, NodeHealthObservation.Success);
+
+            Assert.That(liveNodes.nextAsURI(), Is.EqualTo(activeNode));
+            Assert.That(liveNodes.nextAsURI(), Is.EqualTo(quarantinedNode));
+            Assert.That(liveNodes.nextAsURI(), Is.EqualTo(activeNode));
+        }
+
+        [Test]
+        public void NextAsUriUsesQuarantinedNodeWhenNoActiveNodesExistTest()
+        {
+            using var pollingHttpClient = CreatePollingClient();
+            var liveNodes = CreateLiveNodes(
+                new[] { "node1.example.com" },
+                builder => builder.withQuarantineSuccessThreshold(3),
+                pollingHttpClient);
+            var node = Node("node1.example.com");
+            liveNodes.reportNodeResult(node, NodeHealthObservation.ConnectionFailure);
+            liveNodes.reportNodeResult(node, NodeHealthObservation.Success);
+
+            Assert.That(liveNodes.getActiveNodes(), Is.Empty);
+            Assert.That(liveNodes.getQuarantinedNodes(), Is.EqualTo(new[] { node }));
+            Assert.That(liveNodes.nextAsURI(), Is.EqualTo(node));
+        }
+
+        [Test]
+        public async Task ProbeDownNodesMovesResponsiveNodeToQuarantineTest()
+        {
+            var probeHandler = new FuncHttpMessageHandler((_, _) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[\"node1.example.com\"]"),
+                }));
+            using var pollingHttpClient = new HttpClient(probeHandler);
+            var liveNodes = CreateLiveNodes(
+                new[] { "node1.example.com" },
+                builder => builder.withQuarantineSuccessThreshold(3),
+                pollingHttpClient);
+            var node = Node("node1.example.com");
+            liveNodes.reportNodeResult(node, NodeHealthObservation.ConnectionFailure);
+
+            var probed = await liveNodes.probeDownNodesAsync();
+
+            Assert.That(probed, Is.EqualTo(new[] { node }));
+            Assert.That(liveNodes.getQuarantinedNodes(), Is.EqualTo(new[] { node }));
+            Assert.That(liveNodes.getNodeStatus(node) !.ConsecutiveSuccesses, Is.EqualTo(1));
+            Assert.That(probeHandler.Requests.Single().AbsolutePath, Is.EqualTo("/localnodes"));
+        }
+
+        [Test]
+        public void DiscoveryRemovesMissingDiscoveredNodesFromHealthStoreTest()
+        {
+            var discoveryHandler = new QueueHttpMessageHandler(new[]
+            {
+                "[\"node2.example.com\"]",
+                "[\"node3.example.com\"]",
+            });
+            using var pollingHttpClient = new HttpClient(discoveryHandler);
+            var liveNodes = CreateLiveNodes(new[] { "node1.example.com" }, null, pollingHttpClient);
+
+            InvokeUpdateLiveNodes(liveNodes);
+            Assert.That(liveNodes.getNodeStatus(Node("node2.example.com")), Is.Not.Null);
+
+            InvokeUpdateLiveNodes(liveNodes);
+
+            Assert.That(liveNodes.getNodeStatus(Node("node2.example.com")), Is.Null);
+            Assert.That(liveNodes.getNodeStatus(Node("node3.example.com")), Is.Not.Null);
+            Assert.That(
+                liveNodes.getLiveNodes(),
+                Is.EqualTo(new[] { Node("node3.example.com"), Node("node1.example.com") }));
+        }
+
+        [Test]
+        public async Task HttpReportingHandlerClassifiesQuickServerErrorAndTimeoutShapedServerErrorTest()
+        {
+            using var pollingHttpClient = CreatePollingClient();
+            var quickLiveNodes = CreateLiveNodes(
+                new[] { "node1.example.com" },
+                builder => builder
+                    .withConsecutiveServerErrorThreshold(2)
+                    .withServerRequestTimeoutThresholdMs(1000),
+                pollingHttpClient);
+            using var quickClient = CreateHealthReportingClient(
+                _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError)),
+                quickLiveNodes);
+
+            using var quickResponse = await quickClient.GetAsync(Node("node1.example.com"));
+
+            Assert.That(quickResponse.StatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
+            Assert.That(quickLiveNodes.getNodeStatus(Node("node1.example.com")) !.ConsecutiveServerErrors, Is.EqualTo(1));
+
+            using var timeoutPollingHttpClient = CreatePollingClient();
+            var timeoutLiveNodes = CreateLiveNodes(
+                new[] { "node1.example.com" },
+                builder => builder
+                    .withConsecutiveServerErrorThreshold(1)
+                    .withServerRequestTimeoutThresholdMs(10),
+                timeoutPollingHttpClient);
+            using var timeoutClient = CreateHealthReportingClient(
+                async _ =>
+                {
+                    await Task.Delay(30);
+                    return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+                },
+                timeoutLiveNodes);
+
+            using var timeoutResponse = await timeoutClient.GetAsync(Node("node1.example.com"));
+
+            Assert.That(timeoutResponse.StatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
+            var timeoutStatus = timeoutLiveNodes.getNodeStatus(Node("node1.example.com")) !;
+            Assert.That(timeoutStatus.State, Is.EqualTo(NodeHealthState.Active));
+            Assert.That(timeoutStatus.ConsecutiveServerErrors, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void AlternatorConfigBuilderNormalizesNodeHealthThresholdsTest()
+        {
+            var nodeHealth = NodeHealthStoreConfig.builder()
+                .withConsecutiveServerErrorThreshold(0)
+                .withQuarantineSuccessThreshold(0)
+                .withDownNodeProbePeriodMs(0)
+                .withQuarantineTrafficInterval(0)
+                .withServerRequestTimeoutThresholdMs(0)
+                .disabled()
+                .build();
+            var config = AlternatorConfig.builder()
+                .withNodeHealth(nodeHealth)
+                .build();
+
+            Assert.That(config.getNodeHealth().ConsecutiveServerErrorThreshold, Is.EqualTo(1));
+            Assert.That(config.getNodeHealth().QuarantineSuccessThreshold, Is.EqualTo(1));
+            Assert.That(config.getNodeHealth().DownNodeProbePeriodMs, Is.EqualTo(1));
+            Assert.That(config.getNodeHealth().QuarantineTrafficInterval, Is.EqualTo(1));
+            Assert.That(config.getNodeHealth().ServerRequestTimeoutThresholdMs, Is.EqualTo(0));
+            Assert.That(config.getNodeHealth().Disabled, Is.True);
+        }
+
+        private static AlternatorLiveNodes CreateLiveNodes(
+            IEnumerable<string> hosts,
+            Action<NodeHealthStoreConfigBuilder>? configureNodeHealth,
+            HttpClient pollingHttpClient)
+        {
+            var builder = AlternatorConfig.builder()
+                .withSeedHosts(hosts)
+                .withScheme("http")
+                .withPort(8043)
+                .withRoutingScope(ClusterScope.create());
+            if (configureNodeHealth != null)
+            {
+                var nodeHealthBuilder = NodeHealthStoreConfig.builder();
+                configureNodeHealth(nodeHealthBuilder);
+                builder.withNodeHealth(nodeHealthBuilder.build());
+            }
+
+            return new AlternatorLiveNodes(builder.build(), pollingHttpClient);
+        }
+
+        private static HttpClient CreatePollingClient()
+        {
+            return new HttpClient(new FuncHttpMessageHandler((_, _) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]"),
+                })));
+        }
+
+        private static HttpClient CreateHealthReportingClient(
+            Func<HttpRequestMessage, Task<HttpResponseMessage>> responseFactory,
+            AlternatorLiveNodes liveNodes)
+        {
+            var innerHandler = new FuncHttpMessageHandler((request, _) => responseFactory(request));
+            var handler = CreateHealthReportingHandler(innerHandler, liveNodes);
+            return new HttpClient(handler);
+        }
+
+        private static HttpMessageHandler CreateHealthReportingHandler(
+            HttpMessageHandler innerHandler,
+            AlternatorLiveNodes liveNodes)
+        {
+            var handlerType = typeof(AlternatorConfig).Assembly.GetType("ScyllaDB.Alternator.NodeHealthReportingHttpMessageHandler");
+            Assert.That(handlerType, Is.Not.Null);
+            var config = GetConfig(liveNodes);
+            var value = Activator.CreateInstance(
+                handlerType!,
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                null,
+                new object[] { innerHandler, liveNodes, config.NodeHealth },
+                null);
+            Assert.That(value, Is.Not.Null);
+            return (HttpMessageHandler)value!;
+        }
+
+        private static AlternatorConfig GetConfig(AlternatorLiveNodes liveNodes)
+        {
+            var field = typeof(AlternatorLiveNodes).GetField(
+                "config",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            Assert.That(field, Is.Not.Null);
+            var value = field!.GetValue(liveNodes);
+            Assert.That(value, Is.Not.Null);
+            return (AlternatorConfig)value!;
+        }
+
+        private static void InvokeUpdateLiveNodes(AlternatorLiveNodes liveNodes)
+        {
+            var method = typeof(AlternatorLiveNodes).GetMethod(
+                "UpdateLiveNodes",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            Assert.That(method, Is.Not.Null);
+            method!.Invoke(liveNodes, Array.Empty<object>());
+        }
+
+        private static Uri Node(string host)
+        {
+            return new Uri($"http://{host}:8043");
+        }
+
+        private sealed class FuncHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responseFactory;
+
+            internal FuncHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responseFactory)
+            {
+                this.responseFactory = responseFactory;
+            }
+
+            internal List<Uri> Requests { get; } = new List<Uri>();
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (request.RequestUri != null)
+                {
+                    this.Requests.Add(request.RequestUri);
+                }
+
+                return this.responseFactory(request, cancellationToken);
+            }
+        }
+
+        private sealed class QueueHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly Queue<string> responses;
+
+            internal QueueHttpMessageHandler(IEnumerable<string> responses)
+            {
+                this.responses = new Queue<string>(responses);
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (this.responses.Count == 0)
+                {
+                    throw new InvalidOperationException("No queued discovery response.");
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(this.responses.Dequeue()),
+                });
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements real node-health handling for dead and recovering Alternator nodes, addressing #3.

- Add node health model/config types and a dedicated `NodeHealthStoreConfig.builder()` API.
- Track active, quarantined, and down node states from request outcomes.
- Route normal traffic over active nodes, sample quarantined nodes for recovery, and probe down nodes through `/localnodes`.
- Report AWS SDK HTTP transport outcomes through a delegating handler, including elapsed-time classification for timeout-shaped HTTP 5xx responses.
- Preserve the main client/config builder surface as a single `.withNodeHealth(...)` / `.WithNodeHealth(...)` entry point.
- Add unit tests for state transitions, routing behavior, probing, discovery removal, and HTTP response classification.

## Verification

- `dotnet build ScyllaDB.Alternator.sln`
- `dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj --no-build`