### PR TITLE
Drop VS Code workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "makefile.configureOnOpen": false
-}


### PR DESCRIPTION
## Summary
- remove the committed VS Code workspace settings file
- avoid repository-level editor preference for Makefile extension behavior

## Testing
- not run; configuration-only deletion