### PR TITLE
Add standard FailedToCheck constructors

### DIFF
--- a/FailedToCheck.cs
+++ b/FailedToCheck.cs
@@ -4,13 +4,17 @@ namespace ScyllaDB.Alternator
 
     public class FailedToCheck : Exception
     {
-        public FailedToCheck(string message, Exception cause)
-            : base(message, cause)
+        public FailedToCheck()
         {
         }
 
-        public FailedToCheck(string message)
+        public FailedToCheck(string? message)
             : base(message)
+        {
+        }
+
+        public FailedToCheck(string? message, Exception? innerException)
+            : base(message, innerException)
         {
         }
     }


### PR DESCRIPTION
## Summary
- add a parameterless FailedToCheck constructor
- allow nullable message and inner exception arguments in FailedToCheck constructors
- use the standard innerException parameter name

## Testing
- dotnet test UnitTests/ScyllaDB.Alternator.Test.csproj --no-restore
- dotnet test ScyllaDB.Alternator.sln (fails integration tests because no local Scylla/Alternator service is listening on 127.0.0.1:8080)