### PR TITLE
Align BatchWriteItem affinity query plan

### DIFF
--- a/AffinityQueryPlanInterceptor.cs
+++ b/AffinityQueryPlanInterceptor.cs
@@ -166,30 +166,18 @@ namespace ScyllaDB.Alternator
                 }
             }
 
-            var selectedNode = this.SelectBatchWritePreferredNode(votes);
-            return selectedNode == null ? null : this.LiveNodes.CreateQueryPlan(new[] { selectedNode });
+            var preferredNodes = this.SelectBatchWritePreferredNodes(votes);
+            return preferredNodes.Count == 0 ? null : this.LiveNodes.CreateQueryPlan(preferredNodes);
         }
 
-        private Uri? SelectBatchWritePreferredNode(IReadOnlyDictionary<Uri, int> votes)
+        private IReadOnlyList<Uri> SelectBatchWritePreferredNodes(IReadOnlyDictionary<Uri, int> votes)
         {
-            Uri? preferredNode = null;
-            var preferredVotes = 0;
-            var tied = false;
-            foreach (var vote in votes)
-            {
-                if (vote.Value > preferredVotes)
-                {
-                    preferredNode = vote.Key;
-                    preferredVotes = vote.Value;
-                    tied = false;
-                }
-                else if (vote.Value == preferredVotes)
-                {
-                    tied = true;
-                }
-            }
-
-            return preferredNode == null || tied ? null : preferredNode;
+            return votes
+                .Where(vote => vote.Value > 0)
+                .OrderByDescending(vote => vote.Value)
+                .ThenBy(vote => vote.Key.ToString(), StringComparer.Ordinal)
+                .Select(vote => vote.Key)
+                .ToArray();
         }
     }
 }

--- a/UnitTests/KeyRoutingUnitTests.cs
+++ b/UnitTests/KeyRoutingUnitTests.cs
@@ -462,7 +462,7 @@ namespace ScyllaDB.Alternator
         }
 
         [Test]
-        public void QueryPlanPipelineHandlerBatchWriteVotingSelectsStrictMajorityPreferredNodeTest()
+        public void QueryPlanPipelineHandlerBatchWriteVotingOrdersAllVotedNodesTest()
         {
             var helper = CreateBatchWriteAffinityHelper();
             var sortedNodes = LazyQueryPlan.sortedAffinityNodes(helper.getAlternatorLiveNodes());
@@ -482,8 +482,8 @@ namespace ScyllaDB.Alternator
 
             var actualPlan = InvokeGetOrCreateQueryPlan(handler, request, new Dictionary<string, object>());
             var actualHosts = DrainQueryPlanUris(actualPlan, sortedNodes.Count).Select(uri => uri.Host).ToList();
-            var expectedHosts = new[] { target.Host }
-                .Concat(sortedNodes.Where(node => !node.Equals(target)).Select(node => node.Host))
+            var expectedHosts = new[] { target.Host, other.Host }
+                .Concat(sortedNodes.Where(node => !node.Equals(target) && !node.Equals(other)).Select(node => node.Host))
                 .ToList();
 
             Assert.That(actualHosts, Is.EqualTo(expectedHosts));
@@ -520,7 +520,7 @@ namespace ScyllaDB.Alternator
         }
 
         [Test]
-        public void QueryPlanPipelineHandlerBatchWriteVotingFallsBackOnTieTest()
+        public void QueryPlanPipelineHandlerBatchWriteVotingUsesNodeAddressTieBreakTest()
         {
             var helper = CreateBatchWriteAffinityHelper();
             var sortedNodes = LazyQueryPlan.sortedAffinityNodes(helper.getAlternatorLiveNodes());
@@ -535,7 +535,10 @@ namespace ScyllaDB.Alternator
                     Put(ItemWithId(leftKey, "left")),
                     Delete(KeyWithId(rightKey))));
 
-            Assert.That(InvokeTryCreateBatchWriteAffinityQueryPlan(handler, request), Is.Null);
+            var queryPlan = InvokeTryCreateBatchWriteAffinityQueryPlan(handler, request);
+
+            Assert.That(queryPlan, Is.Not.Null);
+            Assert.That(DrainQueryPlanUris(queryPlan!, sortedNodes.Count), Is.EqualTo(sortedNodes));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #32

Jira: https://scylladb.atlassian.net/browse/DRIVER-654
Epic: https://scylladb.atlassian.net/browse/DRIVER-653

Summary:
- Build a BatchWriteItem preferred-node list from all voted live coordinators.
- Order votes by descending count, then coordinator URI.
- Let the existing query plan try voted nodes before canonical remaining retries.

Tests:
- dotnet test ScyllaDB.Alternator.sln --no-restore --filter Category=Unit